### PR TITLE
🧹 Refactor clipboard copy to use modern API and remove deprecated code

### DIFF
--- a/index.html
+++ b/index.html
@@ -4183,22 +4183,28 @@
       output.value = [baseIntro, reconhecimento, paragrafo2, paragrafo3].filter(Boolean).join('\n\n');
     }
 
-    async function copyJudicialControlText() {
-      const feedback = document.getElementById('copyFeedbackControle');
-      const area = document.getElementById('textoControleJudicial');
+    async function copyToClipboard(area, feedback) {
       if (!area.value.trim()) {
         feedback.textContent = 'Gere o texto antes de copiar.';
         return;
       }
       try {
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          throw new Error('Clipboard API not available');
+        }
         await navigator.clipboard.writeText(area.value);
         feedback.textContent = 'Texto copiado para a área de transferência.';
       } catch (err) {
         area.focus();
         area.select();
-        document.execCommand('copy');
         feedback.textContent = 'Não foi possível copiar automaticamente. Use Ctrl+C.';
       }
+    }
+
+    async function copyJudicialControlText() {
+      const feedback = document.getElementById('copyFeedbackControle');
+      const area = document.getElementById('textoControleJudicial');
+      await copyToClipboard(area, feedback);
     }
 
     function generateAndCopyJudicialText() {
@@ -4284,19 +4290,7 @@
     async function copyStandardText() {
       const feedback = document.getElementById('copyFeedback');
       const area = document.getElementById('textoPadrao');
-      if (!area.value.trim()) {
-        feedback.textContent = 'Gere o texto antes de copiar.';
-        return;
-      }
-      try {
-        await navigator.clipboard.writeText(area.value);
-        feedback.textContent = 'Texto copiado para a área de transferência.';
-      } catch (err) {
-        area.focus();
-        area.select();
-        document.execCommand('copy');
-        feedback.textContent = 'Texto copiado.';
-      }
+      await copyToClipboard(area, feedback);
     }
 
     document.getElementById('btnCopiarTexto').addEventListener('click', copyStandardText);


### PR DESCRIPTION
This change improves the code health of the application by replacing the deprecated `document.execCommand('copy')` method with the modern Clipboard API. It also refactors the code to reduce duplication by introducing a reusable `copyToClipboard` helper function, which handles both the successful copy and the fallback scenario (focusing and selecting the text for manual copying). Consistent feedback messages are now provided in both areas where text can be copied.

---
*PR created automatically by Jules for task [12780286461457939443](https://jules.google.com/task/12780286461457939443) started by @Deltaporto*