### PR TITLE
🎨 Palette: Add accessible labels and tooltips to rating buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-17 - Accessibility of Rating Scales
+**Learning:** The application uses 0-4 numeric buttons and N-C letter buttons for ratings without semantic labels, making them opaque to screen readers ("0", "N").
+**Action:** Always verify that scale/rating buttons have `aria-label` with the full semantic meaning (e.g., "Nenhuma", "Grave") to ensure accessibility and clarity.

--- a/index.html
+++ b/index.html
@@ -3239,7 +3239,7 @@
         const row = document.createElement('div');
         row.className = 'domain-row';
         row.innerHTML = `<div class="domain-label"><span class="domain-code">${d.id}</span> <span class="domain-name">${d.name}</span></div>
-      <div class="note-buttons" data-domain="${d.id}">${[0, 1, 2, 3, 4].map(v => `<button class="note-btn${v === 0 ? ' active' : ''}" data-value="${v}">${v}</button>`).join('')}</div>`;
+      <div class="note-buttons" data-domain="${d.id}">${[0, 1, 2, 3, 4].map(v => `<button class="note-btn${v === 0 ? ' active' : ''}" data-value="${v}" aria-label="${Q_NAMES[v]}" title="${Q_NAMES[v]}">${v}</button>`).join('')}</div>`;
         container.appendChild(row);
       });
     }
@@ -4430,6 +4430,15 @@
     document.getElementById('btnLimparControleJudicial').addEventListener('click', clearJudicialMedicalAndTriage);
 
     // ============ INIT ============
+    // A11y & Tooltips for static buttons
+    document.querySelectorAll('.jc-q-btn').forEach(btn => {
+      const v = +btn.dataset.value;
+      if (Q_NAMES[v]) {
+        btn.setAttribute('aria-label', Q_NAMES[v]);
+        btn.setAttribute('title', Q_NAMES[v]);
+      }
+    });
+
     buildDomainRows(document.getElementById('domAmb'), DOM_AMB);
     buildDomainRows(document.getElementById('domCorpo'), DOM_CORPO);
     buildDomainRows(document.getElementById('domAtivM'), DOM_ATIV_M);


### PR DESCRIPTION
This change improves the accessibility and usability of the rating buttons in the BPC/LOAS calculator. 

**Changes:**
- **Dynamic Buttons:** The numeric rating buttons (0-4) now have `aria-label` and `title` attributes corresponding to their semantic meaning (e.g., "Nenhuma", "Leve", "Moderada", "Grave", "Completa"). This is applied in the `buildDomainRows` function.
- **Static Buttons:** The static rating buttons (N-C) in the "Controle Judicial" section are now enhanced with the same attributes via a script that runs on initialization.

**Why:**
- Screen reader users previously heard opaque labels like "0" or "N". Now they hear "Nenhuma" or "Leve".
- Mouse users now see a tooltip on hover explaining the meaning of the rating, reducing the cognitive load of remembering the scale.

**Verification:**
- Verified using a Playwright script that inspects the attributes on both dynamic and static buttons.
- Confirmed no visual regressions via screenshot.
- Existing tests passed.

---
*PR created automatically by Jules for task [11652265555822808227](https://jules.google.com/task/11652265555822808227) started by @Deltaporto*