### PR TITLE
🎨 Palette: Improve accessibility of toggles and inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-17 - Accessibility of Rating Scales
 **Learning:** The application uses 0-4 numeric buttons and N-C letter buttons for ratings without semantic labels, making them opaque to screen readers ("0", "N").
 **Action:** Always verify that scale/rating buttons have `aria-label` with the full semantic meaning (e.g., "Nenhuma", "Grave") to ensure accessibility and clarity.
+
+## 2026-02-17 - Keyboard Focus on Hidden Inputs
+**Learning:** Custom toggle switches implemented with hidden checkboxes (`opacity: 0`) were completely invisible to keyboard users when focused, as the visual replacement (`.toggle-switch`) lacked focus styles.
+**Action:** When styling custom form controls, ensure the visual replacement element receives a visible focus indicator (e.g., using `:focus-visible + .visual-element`) to support keyboard navigation.

--- a/index.html
+++ b/index.html
@@ -756,6 +756,11 @@
       flex-shrink: 0
     }
 
+    .toggle-label input[type=checkbox]:focus-visible + .toggle-switch {
+      outline: 2px solid var(--blue);
+      outline-offset: 2px
+    }
+
     .toggle-switch::after {
       content: '';
       position: absolute;
@@ -2290,8 +2295,8 @@
         <label><input type="checkbox" id="toggleDark"><svg class="ui-icon sm" aria-hidden="true"><use href="#i-moon"></use></svg>Modo escuro</label>
         <label><input type="checkbox" id="toggleMenor16"><svg class="ui-icon sm" aria-hidden="true"><use href="#i-child"></use></svg>Idade inferior a 16 anos</label>
         <span class="idade-input hidden" id="idadeWrap">Idade:
-          <input type="number" id="inputIdade" min="0" max="15" step="1" value="15" inputmode="numeric">
-          <select id="inputIdadeUnidade">
+          <input type="number" id="inputIdade" min="0" max="15" step="1" value="15" inputmode="numeric" aria-label="Idade">
+          <select id="inputIdadeUnidade" aria-label="Unidade da idade">
             <option value="anos" selected>anos</option>
             <option value="meses">meses</option>
           </select>
@@ -3565,7 +3570,9 @@
 
     function syncModeSwitcher() {
       document.querySelectorAll('#modeSwitcher .mode-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.mode === uiMode);
+        const isActive = btn.dataset.mode === uiMode;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-pressed', isActive);
       });
     }
 


### PR DESCRIPTION
💡 What: Added CSS focus styles for custom toggle switches, `aria-label` attributes for age inputs, and `aria-pressed` logic for mode switcher buttons.
🎯 Why: To improve keyboard navigation visibility and screen reader accessibility for core controls.
📸 Before/After: Added focus ring to toggle switches; inputs now announce "Idade" and "Unidade da idade".
♿ Accessibility:
- Added `:focus-visible` styles to `.toggle-switch` for keyboard focus.
- Added accessible names to `#inputIdade` and `#inputIdadeUnidade`.
- Added programmatic state (`aria-pressed`) to mode toggle buttons.

---
*PR created automatically by Jules for task [1692086023938523658](https://jules.google.com/task/1692086023938523658) started by @Deltaporto*