### PR TITLE
🎨 Palette: Add confirmation to clear actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-02-17 - Keyboard Focus on Hidden Inputs
 **Learning:** Custom toggle switches implemented with hidden checkboxes (`opacity: 0`) were completely invisible to keyboard users when focused, as the visual replacement (`.toggle-switch`) lacked focus styles.
 **Action:** When styling custom form controls, ensure the visual replacement element receives a visible focus indicator (e.g., using `:focus-visible + .visual-element`) to support keyboard navigation.
+
+## 2026-02-17 - Destructive Action Confirmation
+**Learning:** Users can accidentally lose significant progress in complex forms if "Clear" actions are instant.
+**Action:** Always wrap data-clearing functions in a confirmation step (`window.confirm` or modal) to prevent accidental data loss.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -414,6 +414,7 @@ function handleApplyPadrao() {
 
 // Clear
 function handleLimpar() {
+  if (!window.confirm('Tem certeza que deseja limpar todos os dados da calculadora?')) return;
   Object.keys(state).forEach(k => state[k] = 0);
   Object.keys(childDomainBackup).forEach(k => delete childDomainBackup[k]);
   userFilledDomains.clear();
@@ -972,6 +973,7 @@ function resetJudicialControl() {
 }
 
 function clearJudicialMedicalAndTriage() {
+  if (!window.confirm('Tem certeza que deseja limpar as etapas médica e de triagem? A base administrativa será mantida.')) return;
   judicialControl.med = createEmptyJudicialMed();
   judicialControl.triage = { ready: false, status: 'pending', testeA: null, testeB: null, reason: '', route: null };
   clearJudicialTextArea();
@@ -1319,6 +1321,7 @@ function handleUseCurrentAsBase() {
 }
 
 function handleClearComp() {
+  if (!window.confirm('Tem certeza que deseja limpar a comparação e reiniciar o controle judicial?')) return;
   savedINSS = null;
   document.getElementById('compSection').classList.add('hidden');
   document.getElementById('btnClearComp').classList.add('hidden');


### PR DESCRIPTION
💡 What: Added confirmation dialogs to destructive "Clear" actions.
🎯 Why: Prevents accidental data loss for users who have filled out complex forms.
♿ Accessibility: Uses native `window.confirm` which is accessible and keyboard navigable.
📸 Before/After: N/A (Interaction change)

---
*PR created automatically by Jules for task [15686684533525676086](https://jules.google.com/task/15686684533525676086) started by @Deltaporto*