### PR TITLE
⚡ Bolt: Reuse DOM nodes in Conclusive Table grid updates

### DIFF
--- a/src/js/dom-builders.js
+++ b/src/js/dom-builders.js
@@ -15,20 +15,38 @@ export function buildDomainRows(container, domains, labels, names) {
 }
 
 export function buildTabelaGrid(container, labels, ambTab, tabelaConclusivaFn) {
-  let html = '';
-  html += '<div class="tc corner"></div>';
+  if (!container.firstElementChild) {
+    let html = '';
+    html += '<div class="tc corner"></div>';
 
-  labels.forEach(l => {
-    html += `<div class="tc header">${l}</div>`;
-  });
+    labels.forEach(l => {
+      html += `<div class="tc header">${l}</div>`;
+    });
 
-  for (let c = 0; c < 5; c++) {
-    html += `<div class="tc row-header">${labels[c]}</div>`;
-    for (let a = 0; a < 5; a++) {
-      const yes = tabelaConclusivaFn(ambTab, a, c);
-      html += `<div class="tc ${yes ? 'yes' : 'no'}" data-c="${c}" data-a="${a}">${yes ? 'Sim' : 'Não'}</div>`;
+    for (let c = 0; c < 5; c++) {
+      html += `<div class="tc row-header">${labels[c]}</div>`;
+      for (let a = 0; a < 5; a++) {
+        const yes = tabelaConclusivaFn(ambTab, a, c);
+        html += `<div class="tc ${yes ? 'yes' : 'no'}" data-c="${c}" data-a="${a}">${yes ? 'Sim' : 'Não'}</div>`;
+      }
     }
+
+    container.innerHTML = html;
+    return;
   }
 
-  container.innerHTML = html;
+  const cells = container.querySelectorAll('.tc[data-c]');
+  cells.forEach(cell => {
+    const c = +cell.dataset.c;
+    const a = +cell.dataset.a;
+    const yes = tabelaConclusivaFn(ambTab, a, c);
+
+    // Optimization: reuse DOM nodes, only update if changed
+    const isYes = cell.classList.contains('yes');
+    if (isYes !== yes) {
+      cell.classList.toggle('yes', yes);
+      cell.classList.toggle('no', !yes);
+      cell.textContent = yes ? 'Sim' : 'Não';
+    }
+  });
 }


### PR DESCRIPTION
💡 What: The optimization implemented
- Modified `buildTabelaGrid` to reuse existing DOM nodes when updating the Conclusive Table grid instead of rebuilding it entirely using `innerHTML`.
- It now checks if the grid is already built (via `container.firstElementChild`).
- If present, it iterates through cells and updates their classes (`yes`/`no`) and text content (`Sim`/`Não`) only if the value has changed.

🎯 Why: The performance problem it solves
- Rebuilding the grid on every input change (Environmental Factors) causes layout thrashing and destroys DOM state (like focused elements or transient classes added by other modules, e.g., `active-cell`).
- This reduces DOM churn and improves rendering performance, especially on low-end devices.

📊 Impact: Expected performance improvement
- Reduces DOM node creation/destruction by ~25 nodes per update.
- Maintains stable DOM references, allowing smoother transitions and potential for future animations.

🔬 Measurement: How to verify the improvement
- Verified using a Playwright test (`tests/verify_grid_optimization.spec.js`) which confirms DOM node identity is preserved across updates.
- Existing tests pass, ensuring functional correctness.

---
*PR created automatically by Jules for task [10507612368944723679](https://jules.google.com/task/10507612368944723679) started by @Deltaporto*