### PR TITLE
🎨 Palette: Add focus visible styles for keyboard navigation

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3830,3 +3830,16 @@ footer {
     justify-content: center;
   }
 }
+
+/* A11Y FOCUS STYLES (Palette) */
+.note-btn:focus-visible,
+.amb-tab:focus-visible,
+.mode-btn:focus-visible,
+.btn:focus-visible,
+.simulador-summary:focus-visible,
+.idade-input input:focus-visible,
+.idade-input select:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: 0 0 0 2px var(--blue);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--blue) 72%, #fff 28%);
+}

--- a/tests/verify_focus_styles.spec.js
+++ b/tests/verify_focus_styles.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Focus styles verification', () => {
+  test('verify focus styles on interactive elements', async ({ page }) => {
+    // Assumes server is running on port 8000, consistent with other tests
+    await page.goto('http://127.0.0.1:8000/index.html');
+
+    // Verify .note-btn has focus-visible rule
+    const noteBtnHasFocusStyle = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule.selectorText && rule.selectorText.includes('.note-btn:focus-visible')) {
+              return true;
+            }
+          }
+        } catch (e) {}
+      }
+      return false;
+    });
+    expect(noteBtnHasFocusStyle).toBe(true);
+
+    // Verify .amb-tab has focus-visible rule
+    const ambTabHasFocusStyle = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule.selectorText && rule.selectorText.includes('.amb-tab:focus-visible')) {
+              return true;
+            }
+          }
+        } catch (e) {}
+      }
+      return false;
+    });
+    expect(ambTabHasFocusStyle).toBe(true);
+
+    // Verify .mode-btn has focus-visible rule
+    const modeBtnHasFocusStyle = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule.selectorText && rule.selectorText.includes('.mode-btn:focus-visible')) {
+              return true;
+            }
+          }
+        } catch (e) {}
+      }
+      return false;
+    });
+    expect(modeBtnHasFocusStyle).toBe(true);
+
+    // Verify .btn has focus-visible rule
+    const btnHasFocusStyle = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule.selectorText && rule.selectorText.includes('.btn:focus-visible')) {
+              return true;
+            }
+          }
+        } catch (e) {}
+      }
+      return false;
+    });
+    expect(btnHasFocusStyle).toBe(true);
+  });
+});


### PR DESCRIPTION
Improved keyboard accessibility by adding consistent and visible focus indicators to interactive elements like calculator buttons, tabs, and action buttons. The implementation supports High Contrast Mode and includes fallbacks for older browsers. Confirmed via Playwright test and visual inspection.

---
*PR created automatically by Jules for task [13027515347404854164](https://jules.google.com/task/13027515347404854164) started by @Deltaporto*