### PR TITLE
🛡️ Sentinel: Add Content-Security-Policy to dev server

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -43,7 +43,8 @@ function send(res, status, body, type = 'text/plain; charset=utf-8') {
     'Cache-Control': 'no-store',
     'X-Content-Type-Options': 'nosniff',
     'X-Frame-Options': 'DENY',
-    'Referrer-Policy': 'no-referrer'
+    'Referrer-Policy': 'no-referrer',
+    'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none';"
   });
   res.end(body);
 }
@@ -81,7 +82,8 @@ const server = http.createServer((req, res) => {
         'Cache-Control': 'no-store',
         'X-Content-Type-Options': 'nosniff',
         'X-Frame-Options': 'DENY',
-        'Referrer-Policy': 'no-referrer'
+        'Referrer-Policy': 'no-referrer',
+        'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none';"
       });
       res.end(data);
     });


### PR DESCRIPTION
🛡️ Sentinel Security Improvement

Added `Content-Security-Policy` header to the development server (`scripts/serve.js`) to match the policy defined in `index.html`. This ensures consistent security policy application during development and covers non-HTML resources.

**Changes:**
- Modified `scripts/serve.js` to include CSP header in `send` and `fs.readFile` responses.

**Verification:**
- Verified CSP header presence using `curl`.
- Ran unit tests (`npm test`) and E2E tests (`npx playwright test`).

---
*PR created automatically by Jules for task [880728115220896657](https://jules.google.com/task/880728115220896657) started by @Deltaporto*