### PR TITLE
Manage focus on Judicial Control transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,7 @@
       </div>
       <div class="comp-change" id="compChange"></div>
     </div>
-    <div class="judicial-control" id="judicialControlSection">
+    <div class="judicial-control" id="judicialControlSection" tabindex="-1">
       <h3><svg class="ui-icon sm" aria-hidden="true">
           <use href="#i-balance"></use>
         </svg>Controle Judicial</h3>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1534,6 +1534,10 @@ function generateAndCopyJudicialText(event) {
 
 function sendScenarioToJudicialDraft() {
   setUIMode('controle', { scrollToJudicial: false });
+  setTimeout(() => {
+    const section = document.getElementById('judicialControlSection');
+    if (section) section.focus();
+  }, 0);
   notifyJudicialInteraction('btnLevarParaControle');
   applyCurrentQualifiersAsAdminDraft();
   document.getElementById('copyFeedbackControle').textContent = 'Rascunho preenchido. Revise os reconhecimentos do INSS e clique em "Fixar base administrativa".';

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3200,6 +3200,11 @@ header .badge {
   background: linear-gradient(180deg, #16273f, #121f33);
 }
 
+.judicial-control:focus {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
 .standard-text h3,
 .comparison h3,
 .judicial-control h3 {

--- a/tests/focus_navigation.spec.js
+++ b/tests/focus_navigation.spec.js
@@ -1,0 +1,28 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe('Focus Management', () => {
+  test('focus moves to Judicial Control section when switching from Simulator via "Levar para Controle"', async ({ page }) => {
+    await page.goto('http://127.0.0.1:8000/index.html');
+
+    // Switch to Simulator mode
+    await page.click('button[data-mode="simulador"]');
+
+    // Ensure we are in Simulator mode
+    const simulatorDetails = page.locator('#simuladorDetails');
+    await expect(simulatorDetails).toBeVisible();
+
+    // The button should now be visible
+    const btnLevar = page.locator('#btnLevarParaControle');
+    await expect(btnLevar).toBeVisible();
+
+    await btnLevar.click();
+
+    // Expect Judicial Control section to be visible
+    const judicialSection = page.locator('#judicialControlSection');
+    await expect(judicialSection).toBeVisible();
+
+    // Verify focus is on the Judicial Control section
+    await expect(judicialSection).toBeFocused();
+  });
+});


### PR DESCRIPTION
Improved keyboard navigation by managing focus when switching from "Simulador" to "Controle Judicial" mode. Previously, focus was lost when the triggering button disappeared. Now, focus is moved to the Judicial Control section container, ensuring continuity for keyboard users.

---
*PR created automatically by Jules for task [17600422582884890340](https://jules.google.com/task/17600422582884890340) started by @Deltaporto*