### PR TITLE
⚡ Bolt: Throttle scroll and resize events for popover positioning

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -8,6 +8,19 @@ function debounce(func, wait) {
   };
 }
 
+// ⚡ Optimization: Throttle helper for frequent events like scroll/resize
+export function throttle(func, limit) {
+  let inThrottle;
+  return function(...args) {
+    const context = this;
+    if (!inThrottle) {
+      func.apply(context, args);
+      inThrottle = true;
+      setTimeout(() => inThrottle = false, limit);
+    }
+  };
+}
+
 export function bindQGroup(groupId, onPick, onRender, onInteraction = null) {
   document.getElementById(groupId).addEventListener('click', e => {
     const btn = e.target.closest('.jc-q-btn');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,7 +35,7 @@ import {
 import { DOMAIN_HELP_KEYS, SIM_HELP_CONTENT } from './help-content.js';
 import { initStaticRatingA11yLabels } from './a11y.js';
 import { highlightActiveCell, runMainUpdate } from './ui-render.js';
-import { bindJudicialControlEvents } from './events.js';
+import { bindJudicialControlEvents, throttle } from './events.js';
 import {
   computeJudicialTriage as computeJudicialTriageFlow,
   getAtivReclassContext as getAtivReclassContextFlow,
@@ -1810,14 +1810,16 @@ function initSimHelpPopover() {
     if (event.key === 'Escape' && activeSimHelpKey) closeSimHelpPopover();
   });
 
-  window.addEventListener('resize', () => {
+  // ⚡ Optimization: Throttle popover positioning to reduce layout thrashing
+  window.addEventListener('resize', throttle(() => {
     if (activeSimHelpKey) positionSimHelpPopover();
-  });
-  window.addEventListener('scroll', () => {
+  }, 16));
+
+  window.addEventListener('scroll', throttle(() => {
     if (activeSimHelpKey && !window.matchMedia(SIM_HELP_MOBILE_QUERY).matches) {
       positionSimHelpPopover();
     }
-  });
+  }, 16));
 }
 
 bindAppEvents({


### PR DESCRIPTION
💡 **What**: Implemented a `throttle` function and applied it to the `scroll` and `resize` event listeners responsible for positioning the "Simulador Help" popover.
🎯 **Why**: The original implementation executed DOM read/write operations on every scroll and resize event, which can cause layout thrashing and performance degradation, especially on lower-end devices.
📊 **Impact**: Limits the positioning logic execution to once every 16ms (targeting 60fps), significantly reducing the main thread load during these high-frequency events.
🔬 **Measurement**: Verified that the popover still positions correctly using existing Playwright tests (`tests/padrao_medio_help.spec.js` and `tests/impedimento_help.spec.js`) and ensuring unit tests pass.

---
*PR created automatically by Jules for task [12466109033512269774](https://jules.google.com/task/12466109033512269774) started by @Deltaporto*