### PR TITLE
Remove unused function resetCorpoReclassFields

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1009,11 +1009,6 @@ function resetCorpoChangeDetails() {
   judicialControl.med.corpoJud = null;
 }
 
-function resetCorpoReclassFields() {
-  judicialControl.med.corpoKeepAdmin = null;
-  resetCorpoChangeDetails();
-}
-
 function getAdminDraftComplete() {
   const d = judicialControl.adminDraft;
   return d.amb != null

--- a/tests/verify_trace.spec.js
+++ b/tests/verify_trace.spec.js
@@ -98,8 +98,7 @@ test('Security Verification: Trace Log XSS and Structure', async ({ page }) => {
     await expect(trace).toBeVisible();
 
     // Check if the payload appears as text
-    const content = await trace.textContent();
-    expect(content).toContain(maliciousInput);
+    await expect(trace).toContainText(maliciousInput);
 
     // Ensure no image tag was created (XSS check)
     const imgTag = trace.locator('img');


### PR DESCRIPTION
Removed the unused function `resetCorpoReclassFields` from `src/js/main.js`. 
This function was confirmed to be unused in the codebase.
Also fixed a flaky test in `tests/verify_trace.spec.js` which was using synchronous assertions for a debounced input field, causing intermittent failures.
Verified by running `npm test` (unit tests) and `npx playwright test` (E2E tests).

---
*PR created automatically by Jules for task [11977687750815046412](https://jules.google.com/task/11977687750815046412) started by @Deltaporto*