### PR TITLE
🧹 Refactor calculation logic in calcAmbiente and calcAtividades

### DIFF
--- a/src/js/calculations.js
+++ b/src/js/calculations.js
@@ -8,16 +8,18 @@ export function pctToQ(pct) {
   return 4;
 }
 
-export function calcAmbienteFromState(state, domains, pctToQFn = pctToQ) {
+export function calculateScore(state, domains, multiplier, pctToQFn = pctToQ) {
   const sum = domains.reduce((acc, d) => acc + state[d.id], 0);
-  const pct = Math.max(0, (sum * 5) - 0.1);
+  const pct = Math.max(0, (sum * multiplier) - 0.1);
   return { sum, pct: +pct.toFixed(1), q: pctToQFn(pct) };
 }
 
+export function calcAmbienteFromState(state, domains, pctToQFn = pctToQ) {
+  return calculateScore(state, domains, 5, pctToQFn);
+}
+
 export function calcAtividadesFromState(state, domains, pctToQFn = pctToQ) {
-  const sum = domains.reduce((acc, d) => acc + state[d.id], 0);
-  const pct = Math.max(0, (sum * 2.77777777777778) - 0.1);
-  return { sum, pct: +pct.toFixed(1), q: pctToQFn(pct) };
+  return calculateScore(state, domains, 2.77777777777778, pctToQFn);
 }
 
 export function calcCorpoFromState(state, domains, options = {}) {
@@ -60,7 +62,6 @@ export function computeAtivFromDomains(domains, ativDomainIds, pctToQFn = pctToQ
   if (!domains) return null;
   const missing = ativDomainIds.some(id => domains[id] == null);
   if (missing) return null;
-  const sum = ativDomainIds.reduce((acc, id) => acc + domains[id], 0);
-  const pctRaw = Math.max(0, (sum * 2.77777777777778) - 0.1);
-  return { sum, pct: +pctRaw.toFixed(1), q: pctToQFn(pctRaw) };
+  const domainObjs = ativDomainIds.map(id => ({ id }));
+  return calculateScore(domains, domainObjs, 2.77777777777778, pctToQFn);
 }

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -54,11 +54,12 @@ function buildFunction(name, deps = {}) {
 }
 
 const pctToQ = buildFunction('pctToQ');
+const calculateScore = buildFunction('calculateScore');
 const tabelaConclusiva = buildFunction('tabelaConclusiva');
-const calcAmbienteFromState = buildFunction('calcAmbienteFromState', { pctToQ });
-const calcAtividadesFromState = buildFunction('calcAtividadesFromState', { pctToQ });
+const calcAmbienteFromState = buildFunction('calcAmbienteFromState', { pctToQ, calculateScore });
+const calcAtividadesFromState = buildFunction('calcAtividadesFromState', { pctToQ, calculateScore });
 const calcCorpoFromState = buildFunction('calcCorpoFromState');
-const computeAtivFromDomains = buildFunction('computeAtivFromDomains', { pctToQ });
+const computeAtivFromDomains = buildFunction('computeAtivFromDomains', { pctToQ, calculateScore });
 
 test('tabelaConclusiva - regras principais', () => {
   assert.strictEqual(tabelaConclusiva(4, 2, 1), false, 'Corpo N/L sempre indefere');


### PR DESCRIPTION
This PR refactors the calculation logic for `calcAmbiente` and `calcAtividades` (and `computeAtivFromDomains`) to use a shared `calculateScore` helper function. This addresses the code health issue of duplicated logic.

Key changes:
- Created `calculateScore` in `src/js/calculations.js`.
- Updated `calcAmbienteFromState` and `calcAtividadesFromState` to use `calculateScore`.
- Updated `computeAtivFromDomains` to use `calculateScore`.
- Updated `tests/calculations.test.js` to build `calculateScore` and inject it into the dependent functions during testing.

Verified by running `npm test`. All tests passed.

---
*PR created automatically by Jules for task [6887744265961307892](https://jules.google.com/task/6887744265961307892) started by @Deltaporto*