### PR TITLE
🧹 Refactor calculation logic to use common calculateScore

### DIFF
--- a/src/js/calculations.js
+++ b/src/js/calculations.js
@@ -8,16 +8,18 @@ export function pctToQ(pct) {
   return 4;
 }
 
-export function calcAmbienteFromState(state, domains, pctToQFn = pctToQ) {
+export function calculateScore(state, domains, multiplier, pctToQFn) {
   const sum = domains.reduce((acc, d) => acc + state[d.id], 0);
-  const pct = Math.max(0, (sum * 5) - 0.1);
+  const pct = Math.max(0, (sum * multiplier) - 0.1);
   return { sum, pct: +pct.toFixed(1), q: pctToQFn(pct) };
 }
 
+export function calcAmbienteFromState(state, domains, pctToQFn = pctToQ) {
+  return calculateScore(state, domains, 5, pctToQFn);
+}
+
 export function calcAtividadesFromState(state, domains, pctToQFn = pctToQ) {
-  const sum = domains.reduce((acc, d) => acc + state[d.id], 0);
-  const pct = Math.max(0, (sum * 2.77777777777778) - 0.1);
-  return { sum, pct: +pct.toFixed(1), q: pctToQFn(pct) };
+  return calculateScore(state, domains, 2.77777777777778, pctToQFn);
 }
 
 export function calcCorpoFromState(state, domains, options = {}) {

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -54,9 +54,10 @@ function buildFunction(name, deps = {}) {
 }
 
 const pctToQ = buildFunction('pctToQ');
+const calculateScore = buildFunction('calculateScore');
 const tabelaConclusiva = buildFunction('tabelaConclusiva');
-const calcAmbienteFromState = buildFunction('calcAmbienteFromState', { pctToQ });
-const calcAtividadesFromState = buildFunction('calcAtividadesFromState', { pctToQ });
+const calcAmbienteFromState = buildFunction('calcAmbienteFromState', { pctToQ, calculateScore });
+const calcAtividadesFromState = buildFunction('calcAtividadesFromState', { pctToQ, calculateScore });
 const calcCorpoFromState = buildFunction('calcCorpoFromState');
 const computeAtivFromDomains = buildFunction('computeAtivFromDomains', { pctToQ });
 


### PR DESCRIPTION
This PR refactors `calcAmbienteFromState` and `calcAtividadesFromState` in `src/js/calculations.js` to use a new helper function `calculateScore`. This removes duplicated logic for summing domain values and calculating the percentage score. The corresponding unit tests in `tests/calculations.test.js` were also updated to correctly mock/inject the new dependency.

**Changes:**
- Added `calculateScore(state, domains, multiplier, pctToQFn)` to `src/js/calculations.js`.
- Refactored `calcAmbienteFromState` and `calcAtividadesFromState` to delegate to `calculateScore`.
- Updated `tests/calculations.test.js` to build and inject `calculateScore`.

**Verification:**
- Ran `npm test` to ensure all 78 tests pass.
- Verified that `calculateScore` logic matches the original implementation.

---
*PR created automatically by Jules for task [4694095312318417585](https://jules.google.com/task/4694095312318417585) started by @Deltaporto*