### PR TITLE
🧹 Deduplicate event binding logic in events.js

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -21,24 +21,24 @@ export function throttle(func, limit) {
   };
 }
 
-export function bindQGroup(groupId, onPick, onRender, onInteraction = null) {
-  document.getElementById(groupId).addEventListener('click', e => {
-    const btn = e.target.closest('.jc-q-btn');
+function bindEvent(groupId, selector, onPick, onRender, onInteraction = null, transform = val => val) {
+  const element = document.getElementById(groupId);
+  if (!element) return;
+  element.addEventListener('click', e => {
+    const btn = e.target.closest(selector);
     if (!btn) return;
-    onPick(+btn.dataset.value);
+    onPick(transform(btn.dataset.value));
     if (onInteraction) onInteraction(groupId);
     onRender();
   });
 }
 
+export function bindQGroup(groupId, onPick, onRender, onInteraction = null) {
+  bindEvent(groupId, '.jc-q-btn', onPick, onRender, onInteraction, val => +val);
+}
+
 export function bindSegmented(groupId, onPick, onRender, onInteraction = null) {
-  document.getElementById(groupId).addEventListener('click', e => {
-    const btn = e.target.closest('.jc-seg-btn');
-    if (!btn) return;
-    onPick(btn.dataset.value);
-    if (onInteraction) onInteraction(groupId);
-    onRender();
-  });
+  bindEvent(groupId, '.jc-seg-btn', onPick, onRender, onInteraction);
 }
 
 export function bindJudicialControlEvents({


### PR DESCRIPTION
Refactored 'bindQGroup' and 'bindSegmented' in 'src/js/events.js' to use a shared 'bindEvent' helper function. This reduces code duplication and improves maintainability by centralizing the event listener logic. Verified with existing tests and manual Playwright verification.

---
*PR created automatically by Jules for task [14914763483739516013](https://jules.google.com/task/14914763483739516013) started by @Deltaporto*