### PR TITLE
Deduplicate domain creation functions

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,5 +1,0 @@
-
-> calculadora-bpc@1.0.0 start
-> node scripts/serve.js
-
-Servidor local: http://127.0.0.1:8000/index.html

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -14,8 +14,7 @@ import {
 import {
   createDomainState,
   createEmptyAdminCorpoRecognition as createEmptyAdminCorpoRecognitionState,
-  createEmptyAtivReclassDomains as createEmptyAtivReclassDomainsState,
-  createEmptyCorpoReclassDomains as createEmptyCorpoReclassDomainsState,
+  createEmptyDomains as createEmptyDomainsState,
   createEmptyJudicialMed as createEmptyJudicialMedState,
   createJudicialControl
 } from './state.js';
@@ -66,11 +65,11 @@ function createEmptyAdminCorpoRecognition() {
 }
 
 function createEmptyCorpoReclassDomains() {
-  return createEmptyCorpoReclassDomainsState(JC_CORPO_RECLASS_DOMAINS);
+  return createEmptyDomainsState(JC_CORPO_RECLASS_DOMAINS);
 }
 
 function createEmptyAtivReclassDomains() {
-  return createEmptyAtivReclassDomainsState(JC_ATIV_RECLASS_DOMAINS);
+  return createEmptyDomainsState(JC_ATIV_RECLASS_DOMAINS);
 }
 
 function createEmptyJudicialMed() {

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -17,15 +17,8 @@ export function createEmptyAdminCorpoRecognition() {
   return { estruturasReconhecidas: null, prognosticoReconhecido: null };
 }
 
-export function createEmptyCorpoReclassDomains(corpoDomainIds) {
-  return corpoDomainIds.reduce((acc, id) => {
-    acc[id] = null;
-    return acc;
-  }, {});
-}
-
-export function createEmptyAtivReclassDomains(ativDomainIds) {
-  return ativDomainIds.reduce((acc, id) => {
+export function createEmptyDomains(domainIds) {
+  return domainIds.reduce((acc, id) => {
     acc[id] = null;
     return acc;
   }, {});
@@ -37,14 +30,14 @@ export function createEmptyJudicialMed(corpoDomainIds, ativDomainIds) {
     corpoJud: null,
     corpoKeepAdmin: null,
     corpoChangeReason: null,
-    corpoAdminDomains: createEmptyCorpoReclassDomains(corpoDomainIds),
+    corpoAdminDomains: createEmptyDomains(corpoDomainIds),
     corpoJudManual: null,
     corpoAlertReductionConfirmed: false,
     hasAtivMed: null,
     ativMode: null,
     ativMedSimple: null,
     ativMedJustification: '',
-    ativMedDomains: createEmptyAtivReclassDomains(ativDomainIds),
+    ativMedDomains: createEmptyDomains(ativDomainIds),
     ativMedComputed: null
   };
 }

--- a/tests/verify_trace.spec.js
+++ b/tests/verify_trace.spec.js
@@ -98,8 +98,7 @@ test('Security Verification: Trace Log XSS and Structure', async ({ page }) => {
     await expect(trace).toBeVisible();
 
     // Check if the payload appears as text
-    const content = await trace.textContent();
-    expect(content).toContain(maliciousInput);
+    await expect(trace).toContainText(maliciousInput);
 
     // Ensure no image tag was created (XSS check)
     const imgTag = trace.locator('img');


### PR DESCRIPTION
Refactored `src/js/state.js` to deduplicate `createEmptyCorpoReclassDomains` and `createEmptyAtivReclassDomains` into a single generic helper function `createEmptyDomains`. This improves maintainability by reducing code duplication. Updated `src/js/main.js` to use the new helper function. Verified the changes by running both unit tests and Playwright end-to-end tests. Also fixed a flaky test in `tests/verify_trace.spec.js` to use `toContainText` (with retry) instead of `textContent` + `toContain`.

---
*PR created automatically by Jules for task [5935581039503075849](https://jules.google.com/task/5935581039503075849) started by @Deltaporto*