### PR TITLE
feat: toast feedback for judicial control actions

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1155,6 +1155,7 @@ function fixAdminBaseFromDraft() {
   updateComparison(calcAmbiente(), calcAtividades(), calcCorpo());
   clearJudicialTextArea();
   notifyJudicialInteraction('btnFixarBaseAdmin');
+  showToast('Base administrativa fixada com sucesso.', 'success');
   renderJudicialControl();
 }
 
@@ -1537,13 +1538,13 @@ function sendScenarioToJudicialDraft() {
   }, 0);
   notifyJudicialInteraction('btnLevarParaControle');
   applyCurrentQualifiersAsAdminDraft();
-  document.getElementById('copyFeedbackControle').textContent = 'Rascunho preenchido. Revise os reconhecimentos do INSS e clique em "Fixar base administrativa".';
+  showToast('Cenário copiado para o rascunho do Controle Judicial.', 'success');
 }
 
 function handleUseCurrentAsBase() {
   notifyJudicialInteraction('btnUseCurrentAsBase');
   applyCurrentQualifiersAsAdminDraft();
-  document.getElementById('copyFeedbackControle').textContent = 'Rascunho preenchido com os qualificadores atuais da Calculadora. Revise e clique em "Fixar base administrativa".';
+  showToast('Rascunho preenchido com os dados da Calculadora.', 'success');
 }
 
 function handleClearComp() {

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -4,11 +4,15 @@ export function showToast(message, type = 'info', duration = 4000) {
     container = document.createElement('div');
     container.id = 'toast-container';
     container.className = 'toast-container';
+    container.setAttribute('role', 'region');
+    container.setAttribute('aria-label', 'Notificações');
+    container.setAttribute('aria-live', 'polite');
     document.body.appendChild(container);
   }
 
   const toast = document.createElement('div');
   toast.className = `toast toast-${type}`;
+  toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
 
   const iconDiv = document.createElement('div');
   iconDiv.className = 'toast-icon';

--- a/tests/toast_feedback.spec.js
+++ b/tests/toast_feedback.spec.js
@@ -1,0 +1,33 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe('Toast Feedback', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://127.0.0.1:8000/index.html');
+  });
+
+  test('shows success toast for judicial control actions with accessibility attributes', async ({ page }) => {
+    await page.click('button[data-mode="simulador"]');
+
+    await page.click('#btnLevarParaControle');
+    const firstToast = page.locator('.toast-success').last();
+    await expect(firstToast).toBeVisible();
+    await expect(firstToast).toContainText('Cenário copiado para o rascunho do Controle Judicial.');
+
+    const container = page.locator('#toast-container');
+    await expect(container).toHaveAttribute('role', 'region');
+    await expect(container).toHaveAttribute('aria-label', 'Notificações');
+    await expect(container).toHaveAttribute('aria-live', 'polite');
+    await expect(firstToast).toHaveAttribute('role', 'status');
+
+    await page.click('#jcAdminAmbButtons button[data-value="2"]');
+    await page.click('#jcAdminAtivButtons button[data-value="2"]');
+    await page.click('#jcAdminCorpoButtons button[data-value="2"]');
+    await page.click('#jcAdminEstruturasRecButtons button[data-value="nao"]');
+    await page.click('#jcAdminProgRecButtons button[data-value="nao"]');
+    await page.click('#btnFixarBaseAdmin');
+
+    const secondToast = page.locator('.toast-success').last();
+    await expect(secondToast).toContainText('Base administrativa fixada com sucesso.');
+  });
+});


### PR DESCRIPTION
## Summary
- show success toasts for key judicial-control actions (send scenario, use current as base, fix base)
- add accessibility semantics to toast UI (`role`, `aria-live`, labeled region)
- add Playwright coverage for toast feedback and accessibility attributes

## Why
Recreates the intent of #32 on top of current `main`, without stale merge conflicts.

## Validation
- `npm test`
- `npx playwright test tests/toast_feedback.spec.js --reporter=line`

## Replaces
- #32
