### PR TITLE
refactor: replace atividades magic number with named constant

### DIFF
--- a/src/js/calculations.js
+++ b/src/js/calculations.js
@@ -1,3 +1,5 @@
+import { MULTIPLIER_ATIVIDADES } from './constants.js';
+
 export function pctToQ(pct) {
   let normalized = pct;
   if (normalized < 0) normalized = 0;
@@ -19,7 +21,7 @@ export function calcAmbienteFromState(state, domains, pctToQFn = pctToQ) {
 }
 
 export function calcAtividadesFromState(state, domains, pctToQFn = pctToQ) {
-  return calculateScore(state, domains, 2.77777777777778, pctToQFn);
+  return calculateScore(state, domains, MULTIPLIER_ATIVIDADES, pctToQFn);
 }
 
 export function calcCorpoFromState(state, domains, options = {}) {
@@ -63,6 +65,6 @@ export function computeAtivFromDomains(domains, ativDomainIds, pctToQFn = pctToQ
   const missing = ativDomainIds.some(id => domains[id] == null);
   if (missing) return null;
   const sum = ativDomainIds.reduce((acc, id) => acc + domains[id], 0);
-  const pctRaw = Math.max(0, (sum * 2.77777777777778) - 0.1);
+  const pctRaw = Math.max(0, (sum * MULTIPLIER_ATIVIDADES) - 0.1);
   return { sum, pct: +pctRaw.toFixed(1), q: pctToQFn(pctRaw) };
 }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -33,6 +33,8 @@ export const DOM_ATIV_S = [
 
 export const CHILD_AGE_LIMIT_MONTHS = 192;
 
+export const MULTIPLIER_ATIVIDADES = 100 / 36;
+
 export const JC_ATIV_RECLASS_DOMAINS = [...DOM_ATIV_M, ...DOM_ATIV_S].map(d => d.id);
 export const JC_CORPO_RECLASS_DOMAINS = DOM_CORPO.map(d => d.id);
 

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -55,11 +55,12 @@ function buildFunction(name, deps = {}) {
 
 const pctToQ = buildFunction('pctToQ');
 const calculateScore = buildFunction('calculateScore');
+const MULTIPLIER_ATIVIDADES = 100 / 36;
 const tabelaConclusiva = buildFunction('tabelaConclusiva');
 const calcAmbienteFromState = buildFunction('calcAmbienteFromState', { pctToQ, calculateScore });
-const calcAtividadesFromState = buildFunction('calcAtividadesFromState', { pctToQ, calculateScore });
+const calcAtividadesFromState = buildFunction('calcAtividadesFromState', { pctToQ, calculateScore, MULTIPLIER_ATIVIDADES });
 const calcCorpoFromState = buildFunction('calcCorpoFromState');
-const computeAtivFromDomains = buildFunction('computeAtivFromDomains', { pctToQ });
+const computeAtivFromDomains = buildFunction('computeAtivFromDomains', { pctToQ, MULTIPLIER_ATIVIDADES });
 
 test('tabelaConclusiva - regras principais', () => {
   assert.strictEqual(tabelaConclusiva(4, 2, 1), false, 'Corpo N/L sempre indefere');


### PR DESCRIPTION
## Summary
- introduce `MULTIPLIER_ATIVIDADES = 100 / 36` in `src/js/constants.js`
- replace duplicated magic number usage in `calcAtividadesFromState` and `computeAtivFromDomains`
- update unit-test dependency injection in `tests/calculations.test.js`

## Why
Recreates the intent of #43 on top of current `main`, without stale merge conflicts.

## Validation
- `npm test`

## Replaces
- #43
