### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -84,6 +84,11 @@ function send(res, status, body, type = 'text/plain; charset=utf-8') {
 }
 
 const server = http.createServer((req, res) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    send(res, 405, 'Method Not Allowed');
+    return;
+  }
+
   if ((req.url || '').split('?')[0] === '/favicon.ico') {
     res.writeHead(204, SECURITY_HEADERS);
     res.end();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The local development server (`scripts/serve.js`) previously accepted any HTTP method (e.g., POST, PUT, DELETE), falling through to static file serving logic without explicit rejection. While not directly exploitable for code execution due to `fs.readFile` usage, accepting arbitrary methods on a static server violates the principle of least privilege and increases attack surface.
🎯 Impact: Attackers could potentially use unsupported methods to probe the server, bypass simple request filters, or cause unexpected behavior if routing logic changes in the future.
🔧 Fix: Added explicit method validation at the beginning of the `http.createServer` callback. Requests that are not `GET` or `HEAD` are now immediately rejected with a `405 Method Not Allowed` response using the existing `send()` helper.
✅ Verification: Tested locally by verifying `pnpm test` passes and using `curl -I -X POST http://127.0.0.1:8000/` which correctly returns a 405 status code.

---
*PR created automatically by Jules for task [17566707441031796136](https://jules.google.com/task/17566707441031796136) started by @Deltaporto*