### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP method restrictions to local server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The local dev server (`scripts/serve.js`) crashed completely when a requested path contained a null byte (`%00`). `fs.stat` synchronously throws `TypeError [ERR_INVALID_ARG_VALUE]` if the path contains a null byte, which was uncaught and killed the server process.
 **Learning:** Node.js file system APIs like `fs.stat` will throw a synchronous error if passed a path containing a null byte. Even with try-catch blocks elsewhere, synchronous throws on asynchronous-looking Node APIs can lead to severe DoS.
 **Prevention:** Always sanitize or explicitly reject paths containing `\0` immediately after URL decoding, before passing them to any Node.js `fs` or `path` functions.
+## 2026-04-11 - [MEDIUM] Missing HTTP method restrictions
+**Vulnerability:** The local development server (`scripts/serve.js`) previously lacked HTTP method restrictions, allowing it to process potentially unexpected HTTP verbs (like `POST`, `PUT`, `DELETE`). While it only served files, this deviates from security best practices where unexpected methods should be explicitly rejected.
+**Learning:** Simple custom file servers often process all requests identically regardless of the HTTP method. Explicitly filtering allowed methods ensures the server only responds to intended request types.
+**Prevention:** Always check and enforce allowed HTTP methods (e.g., `GET`, `HEAD`) at the entry point of request processing, returning a `405 Method Not Allowed` for unauthorized verbs.

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -84,6 +84,11 @@ function send(res, status, body, type = 'text/plain; charset=utf-8') {
 }
 
 const server = http.createServer((req, res) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    send(res, 405, 'Method Not Allowed');
+    return;
+  }
+
   if ((req.url || '').split('?')[0] === '/favicon.ico') {
     res.writeHead(204, SECURITY_HEADERS);
     res.end();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The local development server (`scripts/serve.js`) lacked HTTP method restrictions and would process any HTTP method (like POST, PUT, DELETE) identically to a GET request.
🎯 Impact: While the server merely serves static files and explicit code execution via POST is unlikely in this setup, ignoring HTTP verbs deviates from security best practices and violates the principle of least privilege.
🔧 Fix: Explicitly restrict the `http.createServer` callback to only process `GET` and `HEAD` requests, responding with a `405 Method Not Allowed` for any other method.
✅ Verification: Confirmed by reviewing `scripts/serve.js` and running the full test suite (`pnpm test`), ensuring the server continues to handle legitimate GET requests successfully while safely rejecting others.

---
*PR created automatically by Jules for task [5692639073473693888](https://jules.google.com/task/5692639073473693888) started by @Deltaporto*