### PR TITLE
🎨 Palette: Add descriptive tooltip for excerpt action

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -493,7 +493,7 @@ function closeSimHelpPopover() {
   if (excerptBtn) {
     excerptBtn.textContent = 'Ver base legal (trecho)';
     excerptBtn.setAttribute('aria-expanded', 'false');
-    excerptBtn.removeAttribute('title');
+    excerptBtn.setAttribute('title', 'Ler o trecho específico da norma que fundamenta este item.');
   }
   if (!popover) return;
   popover.classList.add('hidden');
@@ -582,7 +582,7 @@ function openSimHelpPopover(helpKey, trigger) {
   if (!entry.legalExcerpt) {
     excerptBtn.setAttribute('title', 'Não há trecho legal específico disponível para este item.');
   } else {
-    excerptBtn.removeAttribute('title');
+    excerptBtn.setAttribute('title', 'Ler o trecho específico da norma que fundamenta este item.');
   }
   portariaBtn.dataset.helpKey = helpKey;
   portariaBtn.dataset.portariaSourceKey = entry.portariaSourceKey || DEFAULT_PORTARIA_SOURCE_KEY;


### PR DESCRIPTION
💡 What: Adds a descriptive `title` attribute to the "Ver base legal (trecho)" button when it is enabled.
🎯 Why: Previously, when the button was enabled, the `title` attribute was removed entirely. This left users without a tooltip explaining the action's specific context. Adding an explicit description makes the interface more intuitive.
📸 Before/After: See Playwright verification screenshot.
♿ Accessibility: The addition provides extra context for users who hover over the button or rely on tooltip announcements, ensuring the button's action is clear whether it's disabled or enabled.

---
*PR created automatically by Jules for task [2030146245929662973](https://jules.google.com/task/2030146245929662973) started by @Deltaporto*