### PR TITLE
🎨 Palette: Adicionar barra de progresso visual em Funções do Corpo

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -75,3 +75,7 @@
 ## 2024-05-18 - Prevent hover state on disabled elements
 **Learning:** Native form elements (like `button`) support the `:disabled` pseudo-class natively, while standard elements like `a` or `label` do not. Applying `:not(:disabled)` to links will not work; instead, we must use `:not(.disabled):not([aria-disabled="true"])`.
 **Action:** Always verify if an element is a native form element before using `:disabled` in CSS pseudo-class selection to restrict interactive states.
+
+## 2026-03-08 - Consistent Visual Progress Indicators
+**Learning:** Providing visual progress bars in some panels but not others creates an inconsistent user experience and missing ARIA `role="progressbar"` context for screen readers in the related panels.
+**Action:** Always verify that structurally related scoring/evaluation panels share consistent visual elements (like progress bars) and ARIA attributes for predictability and accessibility.

--- a/index.html
+++ b/index.html
@@ -263,6 +263,9 @@
             </div>
             <div class="panel-result">
               <div class="formula" id="fCorpo"></div>
+              <div class="result-bar" id="barCorpoContainer" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso da pontuação de Funções do Corpo">
+                <div class="result-fill" id="barCorpo"></div>
+              </div>
               <div class="panel-result-row"><span class="qual-name" id="nameCorpo">Nenhuma Alteração</span>
                 <div class="qualifier-badge" id="qCorpo" data-q="N">N</div>
               </div>

--- a/src/js/ui-render.js
+++ b/src/js/ui-render.js
@@ -95,6 +95,8 @@ function ensureRefs() {
     fCorpoSpacer: fCorpoNodes[2],
     fCorpoFinal: fCorpoNodes[3],
     fCorpoSuffix: fCorpoNodes[4],
+    barCorpoContainer: getById('barCorpoContainer'),
+    barCorpo: getById('barCorpo'),
     qCorpo: getById('qCorpo'),
     nameCorpo: getById('nameCorpo'),
     fAtiv: getById('fAtiv'),
@@ -215,6 +217,15 @@ export function runMainUpdate({
   setTextIfChanged(refs.fCorpoFinal, corpo.majorado ? String(corpo.final) : '');
   setTextIfChanged(refs.fCorpoSuffix, corpo.majorado ? ' (majoração +1)' : '');
   setStyleIfChanged(refs.fCorpoFinal, 'display', corpo.majorado ? '' : 'none');
+
+  const corpoPctClamped = Math.min(100, corpo.max * 25);
+  if (refs.barCorpoContainer) {
+    if (refs.barCorpoContainer.getAttribute('aria-valuenow') !== String(corpoPctClamped)) {
+      refs.barCorpoContainer.setAttribute('aria-valuenow', String(corpoPctClamped));
+    }
+  }
+  setStyleIfChanged(refs.barCorpo, 'width', `${corpoPctClamped}%`);
+  setStyleIfChanged(refs.barCorpo, 'background', `var(--q${qLabels[corpo.q]})`);
 
   setQBadgeElement(refs.qCorpo, corpo.q, qLabels);
   setTextIfChanged(refs.nameCorpo, qFull.corpo[corpo.q]);


### PR DESCRIPTION
💡 What: Adicionada a barra de progresso visual (result-bar) na seção "Funções do Corpo".
🎯 Why: Os painéis "Fatores Ambientais" e "Atividades e Participação" possuíam barras visuais de progresso com papéis semânticos (progressbar), enquanto o painel "Funções do Corpo" não. Isso cria inconsistência visual e semântica entre os domínios.
📸 Before/After: A barra foi incluída para visualizar a pontuação da avaliação médica.
♿ Accessibility: Foi incluída com `role="progressbar"`, `aria-valuemin="0"`, `aria-valuemax="100"` e `aria-valuenow` dinâmico para melhorar o suporte a leitores de tela em conformidade com as outras abas.

---
*PR created automatically by Jules for task [13993231565305346639](https://jules.google.com/task/13993231565305346639) started by @Deltaporto*