### PR TITLE
🎨 Palette: Consistent keyboard navigation for flowchart steps

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -75,3 +75,7 @@
 ## 2024-05-18 - Prevent hover state on disabled elements
 **Learning:** Native form elements (like `button`) support the `:disabled` pseudo-class natively, while standard elements like `a` or `label` do not. Applying `:not(:disabled)` to links will not work; instead, we must use `:not(.disabled):not([aria-disabled="true"])`.
 **Action:** Always verify if an element is a native form element before using `:disabled` in CSS pseudo-class selection to restrict interactive states.
+
+## 2026-03-08 - Consistent Keyboard Navigation for Button Groups
+**Learning:** Adding custom radio-button-like groups (e.g., the `.flowchart-step-nav` container for navigation in the Flowchart view) without implementing roving `tabindex` forces keyboard users to `Tab` through each option individually, unlike other similar button groups in the application that use arrow keys. Additionally, these custom groups should use the `role="group"` attribute.
+**Action:** When creating new mutually exclusive custom button groups, ensure they receive `role="group"` and are included in the centralized roving `tabindex` implementation (e.g., by adding their class to `groupSelector` in `a11y.js`) to guarantee consistent and accessible keyboard navigation.

--- a/index.html
+++ b/index.html
@@ -836,7 +836,7 @@
         </svg>Fluxograma Decisório</h3>
       <p class="helper">No celular, use as etapas para leitura guiada. No desktop, a visão geral permanece disponível.</p>
 
-      <nav class="flowchart-step-nav" id="flowchartStepNav" aria-label="Navegação por etapas do fluxograma">
+      <nav class="flowchart-step-nav" id="flowchartStepNav" role="group" aria-label="Navegação por etapas do fluxograma">
         <button type="button" class="is-active" data-flow-step-target="all" aria-pressed="true">Visão geral</button>
         <button type="button" data-flow-step-target="1" aria-pressed="false">Etapa 1</button>
         <button type="button" data-flow-step-target="2" aria-pressed="false">Etapa 2</button>

--- a/src/js/a11y.js
+++ b/src/js/a11y.js
@@ -21,7 +21,7 @@ export function initStaticRatingA11yLabels(labels) {
 export function initKeyboardNav() {
   // ⚡ Optimization: Direct querySelectorAll (NodeList) instead of Array.from to avoid array allocation on every interaction
   const getGroupButtons = (group) => group.querySelectorAll('button:not([disabled])');
-  const groupSelector = '.note-buttons, .jc-q-buttons, .jc-segmented, .amb-tabs, .jc-segmented-wide, .app-mode-switch';
+  const groupSelector = '.note-buttons, .jc-q-buttons, .jc-segmented, .amb-tabs, .jc-segmented-wide, .app-mode-switch, .flowchart-step-nav';
 
   // Initialize static groups
   document.querySelectorAll(groupSelector).forEach(group => {


### PR DESCRIPTION
### 💡 What
Added `role="group"` to the flowchart step navigation container (`#flowchartStepNav`) and included it in the application's centralized roving `tabindex` implementation in `src/js/a11y.js`.

### 🎯 Why
The custom radio-button-like group for the flowchart navigation was missing from the roving tabindex logic applied to other similar components in the application. This forced keyboard users to `Tab` through each option individually instead of using arrow keys, causing an inconsistent and tedious navigation experience.

### 📸 Before/After
*(Visuals validated via frontend verification; no visible styling change, but keyboard focus behavior is updated.)*

### ♿ Accessibility
*   **Keyboard Navigation:** Users can now focus the active flowchart step and use arrow keys (←/→) to seamlessly navigate between steps.
*   **Screen Reader Context:** Added `role="group"` to correctly announce the flowchart step navigation as a cohesive group of options.

---
*PR created automatically by Jules for task [6337503592624736997](https://jules.google.com/task/6337503592624736997) started by @Deltaporto*