### PR TITLE
⚡ Bolt: [performance improvement] Eliminate intermediate array allocation in resolveCorpoJudFlow

### DIFF
--- a/src/js/judicial-flow.js
+++ b/src/js/judicial-flow.js
@@ -131,22 +131,33 @@ export function resolveCorpoJudFlow({
   }
 
   if (med.corpoChangeReason === 'dominio_max') {
-    const filledDomains = corpoDomainIds.filter(id => med.corpoAdminDomains[id] != null);
-    if (!filledDomains.length) {
-      return { ready: false, q: null, reason: 'No motivo "Domínio administrativo b1–b8 mais grave", informe ao menos um domínio b1 a b8.', mode: 'pending' };
-    }
-    // ⚡ Optimization: Native for-loop to avoid Array.prototype.reduce callback allocation overhead
+    // ⚡ Optimization: Native for-loop to avoid Array.prototype.filter and map callback allocation overhead
     let q = 0;
-    for (let i = 0; i < filledDomains.length; i++) {
-      const val = med.corpoAdminDomains[filledDomains[i]];
-      if (val > q) q = val;
+    let hasFilled = false;
+    let textParts = '';
+    for (let i = 0; i < corpoDomainIds.length; i++) {
+      const id = corpoDomainIds[i];
+      const val = med.corpoAdminDomains[id];
+      if (val != null) {
+        if (!hasFilled) {
+          hasFilled = true;
+          textParts = `${id.toUpperCase()}=${qLabels[val]}`;
+        } else {
+          textParts += ` · ${id.toUpperCase()}=${qLabels[val]}`;
+        }
+        if (val > q) q = val;
+      }
+    }
+
+    if (!hasFilled) {
+      return { ready: false, q: null, reason: 'No motivo "Domínio administrativo b1–b8 mais grave", informe ao menos um domínio b1 a b8.', mode: 'pending' };
     }
     return {
       ready: true,
       q,
       mode: 'dominio_max',
       reason: 'Regra aplicada: para Funções do Corpo prevalece o domínio administrativo mais grave entre os domínios informados (b1–b8).',
-      domainsText: filledDomains.map(id => `${id.toUpperCase()}=${qLabels[med.corpoAdminDomains[id]]}`).join(' · '),
+      domainsText: textParts,
       decreased: q < base.corpo
     };
   }


### PR DESCRIPTION
💡 What: Replaced `.filter().map().join()` with a single native `for` loop inside `resolveCorpoJudFlow` for the `dominio_max` calculation path.
🎯 Why: In a hot path that handles judicial flow resolution during rendering cycles, chained array methods create unnecessary intermediate array allocations, adding to garbage collection pressure and callback execution overhead.
📊 Impact: Reduces memory allocation and avoids two intermediate array copies, computing the max value and building the formatted string in a single O(N) pass.
🔬 Measurement: Verify tests run perfectly with no logic deviation (`node --test tests/*.test.js`) and profile GC collections in high frequency flow changes.

---
*PR created automatically by Jules for task [14767337562664236158](https://jules.google.com/task/14767337562664236158) started by @Deltaporto*