### PR TITLE
🎨 Palette: Add explicit focus styles to dialog containers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -75,3 +75,7 @@
 ## 2024-05-18 - Prevent hover state on disabled elements
 **Learning:** Native form elements (like `button`) support the `:disabled` pseudo-class natively, while standard elements like `a` or `label` do not. Applying `:not(:disabled)` to links will not work; instead, we must use `:not(.disabled):not([aria-disabled="true"])`.
 **Action:** Always verify if an element is a native form element before using `:disabled` in CSS pseudo-class selection to restrict interactive states.
+
+## 2026-03-09 - Focus Rings on Dialog Containers
+**Learning:** Native `<dialog>` elements and custom popover containers used with programmatically shifted focus (`tabindex="-1"`) do not inherently receive consistent or aesthetically pleasing `:focus-visible` outlines from browsers, which can break visual harmony and lower accessibility quality when keyboard navigating.
+**Action:** Always include `.sim-help-popover:focus-visible` and `.portaria-modal:focus-visible` (or equivalent dialog classes) within the global explicit `:focus-visible` reset block to ensure clear, consistent focus styling when they receive focus.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4415,6 +4415,8 @@ footer {
 .jc-select:focus-visible,
 .standard-text textarea:focus-visible,
 .toast-close:focus-visible,
+.sim-help-popover:focus-visible,
+.portaria-modal:focus-visible,
 .toggle-label:has(input[type=checkbox]:focus-visible),
 .jc-reduction-alert label:has(input[type=checkbox]:focus-visible) {
   outline: 2px solid transparent;


### PR DESCRIPTION
💡 What: Added explicit `:focus-visible` styles to dialog and popover containers (`.sim-help-popover`, `.portaria-modal`).\n🎯 Why: Native `<dialog>` elements and programmatic popovers often receive an ugly browser-default focus ring or none at all when focused, degrading keyboard navigation experience.\n📸 Before/After: Before, hitting Tab to enter the popover or modal resulted in no clear visual focus state for the container. After, the containers receive a consistent blue glow matching the rest of the app's interactive elements.\n♿ Accessibility: Improves visual indication of focus for keyboard navigators interacting with modal/popover content.

---
*PR created automatically by Jules for task [12111859912150370144](https://jules.google.com/task/12111859912150370144) started by @Deltaporto*