### PR TITLE
🎨 Palette: Add focus visibility for native dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -75,3 +75,7 @@
 ## 2024-05-18 - Prevent hover state on disabled elements
 **Learning:** Native form elements (like `button`) support the `:disabled` pseudo-class natively, while standard elements like `a` or `label` do not. Applying `:not(:disabled)` to links will not work; instead, we must use `:not(.disabled):not([aria-disabled="true"])`.
 **Action:** Always verify if an element is a native form element before using `:disabled` in CSS pseudo-class selection to restrict interactive states.
+
+## 2026-03-09 - Focus Visibility on Native Dialogs
+**Learning:** Native `<dialog>` elements and custom popover containers that receive programmatic focus (`tabindex="-1"`) may lack consistent browser-default `:focus-visible` outlines, rendering them invisible to keyboard navigation.
+**Action:** Always explicitly style `:focus-visible` for container elements like native dialogs and popovers to ensure clear focus indication for keyboard and screen reader users when they are opened and focused.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3821,6 +3821,11 @@ footer {
   color: var(--text);
 }
 
+.sim-help-popover:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--blue) 72%, #fff 28%);
+  outline-offset: 2px;
+}
+
 .sim-help-popover-header {
   display: flex;
   align-items: center;
@@ -3960,6 +3965,11 @@ footer {
   color: var(--text);
   background: var(--surface);
   box-shadow: var(--shadow-lg);
+}
+
+.portaria-modal:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--blue) 72%, #fff 28%);
+  outline-offset: 2px;
 }
 
 .portaria-modal::backdrop {


### PR DESCRIPTION
💡 **What:** Added explicit `:focus-visible` styling (`outline: 2px solid`) to the `.portaria-modal` (native dialog) and `.sim-help-popover` containers when they receive keyboard focus. Also added a new critical learning to `.Jules/palette.md`.
🎯 **Why:** Keyboard and screen reader users can trigger popovers and dialogs programmatically. Native `<dialog>` tags and elements with `tabindex="-1"` often lack visible browser-default outlines, confusing users as to where focus landed.
📸 **Before/After:** Before, dialogs opened silently without visual focus rings. After, they receive a clear 2px blue outline ring when focused programmatically, keeping keyboard users oriented.
♿ **Accessibility:** This directly supports WCAG Success Criterion 2.4.7 (Focus Visible) by providing a clear, highly visible focus indicator for modal and popover dialog containers when they become active.

---
*PR created automatically by Jules for task [3827989478599467710](https://jules.google.com/task/3827989478599467710) started by @Deltaporto*