### PR TITLE
⚡ Bolt: O(1) hash map lookup for Padrao Medio Apply Context

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -50,3 +50,7 @@ Instead, a significantly safer optimization is removing global queries like `doc
 ## 2025-10-27 - Eliminate Intermediate Allocations in Render Loop Tracking
 **Learning:** During UI rendering, tracking invalid elements using an intermediate `Set` and spreading it to an array (`[...uniqueIds]`) solely to ensure uniqueness before applying DOM classes creates completely unnecessary memory allocations and garbage collection pressure on every change. Since DOM mutation APIs or local `Set`s (like `currentInvalidElements`) already prevent redundant operations, the intermediate deduplication step is a net-negative micro-optimization.
 **Action:** Removed intermediate `Set` and array spread allocations in high-frequency validation tracking. Pass the raw items array directly to the DOM-updating function and rely on the existing state-tracking `Set` to prevent redundant operations.
+
+## 2025-05-23 - Avoid O(N*M) lookups in Render Loops
+**Learning:** In hot rendering paths like `getPadraoApplyContext`, using `Array.prototype.find()` unconditionally on every element inside an existing iteration loop creates an O(N*M) lookup penalty. Converting the target array to a pre-computed hash map for O(1) lookups completely avoids this repeated internal traversal.
+**Action:** Replaced `.find()` over `ATIV_DOMAINS` with O(1) module-level hash map lookups (`ATIV_DOMAINS_MAP`) initialized using `Object.create(null)` to eliminate O(N*M) nested loop overhead.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -56,6 +56,8 @@ import { initFlowchartView } from './flowchart-view.js';
 // ============ STATE ============
 const ALL_DOMAINS = [...DOM_AMB, ...DOM_CORPO, ...DOM_ATIV_M, ...DOM_ATIV_S];
 const ATIV_DOMAINS = [...DOM_ATIV_M, ...DOM_ATIV_S];
+const ATIV_DOMAINS_MAP = Object.create(null);
+ATIV_DOMAINS.forEach(d => ATIV_DOMAINS_MAP[d.id] = d);
 const state = createDomainState(ALL_DOMAINS);
 let progDesfav = false, estrMaior = false, impedimento = false, crianca = false, idadeMeses = CHILD_AGE_LIMIT_MONTHS, idadeValor = 15, idadeUnidade = 'anos';
 let savedINSS = null;
@@ -615,15 +617,31 @@ function toggleSimHelpPopover(trigger) {
 // Padrão Médio Social
 function getPadraoApplyContext() {
   let skippedByAgeCut = 0;
-  const eligibleEntries = PADRAO_MEDIO_ENTRIES.filter(([id]) => {
+  const eligibleEntries = [];
+  const manuallyFilledEligible = [];
+  const entriesPreserve = [];
+
+  for (let i = 0; i < PADRAO_MEDIO_ENTRIES.length; i++) {
+    const entry = PADRAO_MEDIO_ENTRIES[i];
+    const id = entry[0];
+
     if (crianca) {
-      const d = ATIV_DOMAINS.find(x => x.id === id);
-      if (d && idadeMeses < d.cut) { skippedByAgeCut++; return false; }
+      const d = ATIV_DOMAINS_MAP[id];
+      if (d && idadeMeses < d.cut) {
+        skippedByAgeCut++;
+        continue;
+      }
     }
-    return true;
-  });
-  const manuallyFilledEligible = eligibleEntries.filter(([id]) => userFilledDomains.has(id));
-  const entriesPreserve = eligibleEntries.filter(([id]) => !userFilledDomains.has(id));
+
+    eligibleEntries.push(entry);
+    const hasFilled = userFilledDomains.has(id);
+    if (hasFilled) {
+      manuallyFilledEligible.push(entry);
+    } else {
+      entriesPreserve.push(entry);
+    }
+  }
+
   const entriesOverwrite = eligibleEntries;
   return { eligibleEntries, manuallyFilledEligible, entriesPreserve, entriesOverwrite, skippedByAgeCut };
 }

--- a/tests/padrao-medio.portaria.test.js
+++ b/tests/padrao-medio.portaria.test.js
@@ -181,10 +181,14 @@ test('configured padrao values match Portaria 34/2025 Anexo II', () => {
 });
 
 test('getPadraoApplyContext excludes child non-eligible domains by age cut', () => {
+  const ATIV_DOMAINS_TEMP = [...DOM_ATIV_M, ...DOM_ATIV_S];
+  const ATIV_DOMAINS_MAP_TEMP = Object.create(null);
+  ATIV_DOMAINS_TEMP.forEach(d => ATIV_DOMAINS_MAP_TEMP[d.id] = d);
   const ctx = {
     DOM_ATIV_M,
     DOM_ATIV_S,
     ATIV_DOMAINS: [...DOM_ATIV_M, ...DOM_ATIV_S],
+    ATIV_DOMAINS_MAP: ATIV_DOMAINS_MAP_TEMP,
     crianca: true,
     idadeMeses: 5,
     userFilledDomains: new Set(['e1', 'd6', 'd8']),
@@ -200,10 +204,14 @@ test('getPadraoApplyContext excludes child non-eligible domains by age cut', () 
 });
 
 test('getPadraoApplyContext keeps all mapped domains in adult mode', () => {
+  const ATIV_DOMAINS_TEMP = [...DOM_ATIV_M, ...DOM_ATIV_S];
+  const ATIV_DOMAINS_MAP_TEMP = Object.create(null);
+  ATIV_DOMAINS_TEMP.forEach(d => ATIV_DOMAINS_MAP_TEMP[d.id] = d);
   const ctx = {
     DOM_ATIV_M,
     DOM_ATIV_S,
     ATIV_DOMAINS: [...DOM_ATIV_M, ...DOM_ATIV_S],
+    ATIV_DOMAINS_MAP: ATIV_DOMAINS_MAP_TEMP,
     crianca: false,
     idadeMeses: 192,
     userFilledDomains: new Set(['e1', 'd6', 'd8']),
@@ -223,6 +231,9 @@ test('applyPadraoEntries updates state, button activation, and triggers one upda
   const { document, buttonMap } = createDomainDocument(['e1', 'd6', 'd9'], state);
   let updates = 0;
 
+  const ATIV_DOMAINS_TEMP = [...DOM_ATIV_M, ...DOM_ATIV_S];
+  const ATIV_DOMAINS_MAP_TEMP = Object.create(null);
+  ATIV_DOMAINS_TEMP.forEach(d => ATIV_DOMAINS_MAP_TEMP[d.id] = d);
   const ctx = {
     state,
     document,


### PR DESCRIPTION
💡 What: Replaced the `Array.prototype.find()` lookup inside `getPadraoApplyContext()` with a pre-computed module-level hash map (`ATIV_DOMAINS_MAP`). We also replaced the three subsequent `.filter()` iterations on the same base array into a single fused `for` loop that populates all specific tracking arrays concurrently.
🎯 Why: `getPadraoApplyContext()` is called frequently in UI flows to evaluate eligibility for the "Padrão Médio Social". During this evaluation, the `Array.find()` performed inside the existing array callback created an O(N*M) traversal penalty. By constructing an O(1) lookup dictionary once via `Object.create(null)` at startup, we eliminate this completely. Combining the filters eliminates multi-pass overhead. 
📊 Impact: Reduces array iteration passes from 4 to 1 per execution, entirely removes intermediate callback dispatch taxes, and converts an O(N*M) subset search into a guaranteed O(1) memory lookup in a hot path.
🔬 Measurement: Verified by `node --test tests/padrao-medio.portaria.test.js` where contexts were updated to inject the new dependency safely without breaking encapsulation.

---
*PR created automatically by Jules for task [3442618779592138714](https://jules.google.com/task/3442618779592138714) started by @Deltaporto*