### PR TITLE
🛡️ Sentinel: [security improvement] Add URI length limits and global timeouts to dev server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The local development server (`scripts/serve.js`) previously lacked HTTP method restrictions, allowing it to process potentially unexpected HTTP verbs (like `POST`, `PUT`, `DELETE`). While it only served files, this deviates from security best practices where unexpected methods should be explicitly rejected.
 **Learning:** Simple custom file servers often process all requests identically regardless of the HTTP method. Explicitly filtering allowed methods ensures the server only responds to intended request types.
 **Prevention:** Always check and enforce allowed HTTP methods (e.g., `GET`, `HEAD`) at the entry point of request processing, returning a `405 Method Not Allowed` for unauthorized verbs.
+## 2026-05-15 - [MEDIUM] URI Length and Global Timeout DoS
+**Vulnerability:** The local dev server (`scripts/serve.js`) lacked URI length limits and global timeouts, making it vulnerable to Slowloris and URI-based Denial of Service (DoS) attacks.
+**Learning:** Custom HTTP servers created with `http.createServer` do not inherit production-grade limits by default. They will accept extremely long URIs and keep connections open indefinitely if not explicitly configured.
+**Prevention:** Always implement explicit request validation (like `req.url.length > 2048`) and configure global timeouts (`server.setTimeout(30000)`) to mitigate resource exhaustion attacks.

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -84,6 +84,12 @@ function send(res, status, body, type = 'text/plain; charset=utf-8') {
 }
 
 const server = http.createServer((req, res) => {
+  // Security: Prevent DoS from overly long URIs
+  if (req.url && req.url.length > 2048) {
+    send(res, 414, 'URI Too Long');
+    return;
+  }
+
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     send(res, 405, 'Method Not Allowed');
     return;
@@ -124,6 +130,8 @@ const server = http.createServer((req, res) => {
     });
   });
 });
+
+server.setTimeout(30000);
 
 server.listen(port, host, () => {
   console.log(`Servidor local: http://${host}:${port}/index.html`);

--- a/tests/server_security.test.js
+++ b/tests/server_security.test.js
@@ -84,6 +84,20 @@ test('Server Security', async (t) => {
         }
     });
 
+    await t.test('Server handles extremely long URIs with 414', async () => {
+        try {
+            const longPath = '/' + 'a'.repeat(2048);
+            const res = await makeRequest(longPath);
+            assert.strictEqual(res.statusCode, 414, 'Should return 414 URI Too Long status code, got ' + res.statusCode);
+        } catch (e) {
+             if (e.code === 'ECONNRESET' || e.message === 'socket hang up') {
+                 assert.fail('Server crashed on long URI: ' + e.message);
+             } else {
+                 throw e;
+             }
+        }
+    });
+
     // Verify server is still running by making a valid request
     await t.test('Server is still alive', async () => {
          try {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The local development server (`scripts/serve.js`) lacked explicit URI length limits and global timeouts. This made it vulnerable to URI-based Denial of Service (sending massively long URIs) and Slowloris attacks (keeping connections open indefinitely).
🎯 Impact: An attacker could crash the local server process by exhausting memory with excessively long URIs or exhaust connection pools by leaving connections open, preventing legitimate development use.
🔧 Fix: Implemented a check at the start of the `http.createServer` callback to immediately return a `414 URI Too Long` response if the requested URL exceeds 2048 characters. Additionally, configured a global 30-second timeout on the server instance using `server.setTimeout(30000)`.
✅ Verification: Verify the fix by running `pnpm test`. A new test `Server handles extremely long URIs with 414` has been added to `tests/server_security.test.js` which confirms the correct 414 status code is returned.

---
*PR created automatically by Jules for task [8268694550194843645](https://jules.google.com/task/8268694550194843645) started by @Deltaporto*