### PR TITLE
🎨 Palette: Programmatically Focused Dialog Outlines

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2025-05-17 - Programmatically Focused Dialog Outlines
 **Learning:** Native `<dialog>` elements and custom popovers that receive programmatic focus (`tabindex="-1"`) may lack consistent browser-default `:focus-visible` outlines. Always explicitly style `:focus-visible` for these container elements (e.g., `.portaria-modal:focus-visible`) to ensure accessibility during keyboard navigation.
 **Action:** When creating native `<dialog>` elements or programmatic modal containers, always append them to the global `:focus-visible` outline styles list (e.g. alongside `.btn:focus-visible`) to ensure keyboard users have visual feedback that focus has successfully moved to the modal.
+
+## 2025-05-17 - Programmatically Focused Native Elements
+**Learning:** Certain standard block elements used as wrappers (like `.simulador-details`, `.judicial-control`, `.flowchart-view`, `.sim-help-popover`) that receive programmatic focus via `tabindex="-1"` may lack consistent browser-default `:focus-visible` outlines just like `<dialog>` elements. Always explicitly style `:focus-visible` for these programmatic containers to ensure accessibility during keyboard navigation.
+**Action:** When creating programmatic focus targets for routing or focus-management (e.g. for skip links or modal-like popovers), always append them to the global `:focus-visible` outline styles list to ensure keyboard users have visual feedback that focus has successfully moved.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4417,7 +4417,11 @@ footer {
 .toast-close:focus-visible,
 .toggle-label:has(input[type=checkbox]:focus-visible),
 .jc-reduction-alert label:has(input[type=checkbox]:focus-visible),
-.portaria-modal:focus-visible {
+.portaria-modal:focus-visible,
+.sim-help-popover:focus-visible,
+.simulador-details:focus-visible,
+.judicial-control:focus-visible,
+.flowchart-view:focus-visible {
   outline: 2px solid transparent;
   box-shadow: 0 0 0 2px var(--blue);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--blue) 72%, #fff 28%);


### PR DESCRIPTION
💡 What: Added `:focus-visible` styles to `.sim-help-popover`, `.simulador-details`, `.judicial-control`, and `.flowchart-view` inside `src/styles/main.css`.
🎯 Why: Elements acting as routing containers that receive programmatic focus via `tabindex="-1"` (e.g. for skip links or modal-like routing) lacked consistent browser-default `:focus-visible` outlines, making it unclear to keyboard users if focus was properly shifted.
📸 Before/After: Visual outline now visible via standard `:focus-visible` ring.
♿ Accessibility: Keyboard users now have visual feedback when skip links route them to standard layout sections.

---
*PR created automatically by Jules for task [15996524033964136304](https://jules.google.com/task/15996524033964136304) started by @Deltaporto*