### PR TITLE
⚡ Bolt: Replace Set.prototype.forEach with for...of in validation clear

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -69,3 +69,7 @@ Instead, a significantly safer optimization is removing global queries like `doc
 ## 2024-05-20 - [Eliminated callback allocation overhead in critical loops]
 **Learning:** Functional array methods (`.forEach`, `.map`, etc.) combined with `.querySelectorAll` inside frequently executed functions (like UI updates, tab switches, and rule application) create significant, measurable memory allocation and garbage collection pressure due to NodeList and callback function allocations. This is particularly noticeable in complex forms.
 **Action:** For all DOM manipulation loops or data iterations on the hot path, standard native `for` loops combined with live `HTMLCollection`s (e.g. `getElementsByClassName`) should be used over functional array wrappers and `.querySelectorAll()` to ensure consistent performance.
+
+## 2025-10-28 - Replace Set.prototype.forEach with Native Loops
+**Learning:** During frequent UI rendering operations (e.g. clearing validation errors), using `Set.prototype.forEach` introduces callback dispatch overhead and potential garbage collection pressure compared to native C++ backed standard loops.
+**Action:** Replace `Set.prototype.forEach` with standard native `for...of` loops when iterating over `Set` objects in performance-sensitive contexts to bypass callback allocation overhead.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -931,10 +931,11 @@ function notifyJudicialInteraction(sourceId) {
 const currentInvalidElements = new Set();
 
 function clearJudicialInvalidHighlights() {
-  currentInvalidElements.forEach(el => {
+  // ⚡ Optimization: Native for...of loop to prevent Set.prototype.forEach callback allocation overhead
+  for (const el of currentInvalidElements) {
     el.classList.remove('jc-invalid');
     el.removeAttribute('aria-invalid');
-  });
+  }
   currentInvalidElements.clear();
 }
 


### PR DESCRIPTION
💡 **What:** Replaced `Set.prototype.forEach` with a standard native `for...of` loop when clearing validation errors.
🎯 **Why:** To eliminate callback dispatch overhead and potential garbage collection pressure during high-frequency UI rendering paths.
📊 **Impact:** Reduces memory allocation overhead per render cycle when updating DOM elements.
🔬 **Measurement:** Verified no regressions in Node.js test suite.

---
*PR created automatically by Jules for task [14460568976481315161](https://jules.google.com/task/14460568976481315161) started by @Deltaporto*