### PR TITLE
⚡ Bolt: Replace Set.forEach with for...of in clearJudicialInvalidHighlights

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -69,3 +69,7 @@ Instead, a significantly safer optimization is removing global queries like `doc
 ## 2024-05-20 - [Eliminated callback allocation overhead in critical loops]
 **Learning:** Functional array methods (`.forEach`, `.map`, etc.) combined with `.querySelectorAll` inside frequently executed functions (like UI updates, tab switches, and rule application) create significant, measurable memory allocation and garbage collection pressure due to NodeList and callback function allocations. This is particularly noticeable in complex forms.
 **Action:** For all DOM manipulation loops or data iterations on the hot path, standard native `for` loops combined with live `HTMLCollection`s (e.g. `getElementsByClassName`) should be used over functional array wrappers and `.querySelectorAll()` to ensure consistent performance.
+
+## 2026-05-18 - Avoid Set.prototype.forEach overhead in DOM rendering
+**Learning:** Replaced `Set.prototype.forEach` with native `for...of` loops in DOM manipulation routines (like clearing invalid element highlights) to remove callback dispatch overhead during rendering.
+**Action:** Always prefer native `for...of` loops when iterating over `Set` collections in rendering hot paths to minimize allocation and dispatch taxes.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -931,10 +931,10 @@ function notifyJudicialInteraction(sourceId) {
 const currentInvalidElements = new Set();
 
 function clearJudicialInvalidHighlights() {
-  currentInvalidElements.forEach(el => {
+  for (const el of currentInvalidElements) {
     el.classList.remove('jc-invalid');
     el.removeAttribute('aria-invalid');
-  });
+  }
   currentInvalidElements.clear();
 }
 


### PR DESCRIPTION
💡 What: Replaced the `Set.prototype.forEach` call with a native `for...of` loop in the `clearJudicialInvalidHighlights` function (`src/js/main.js`).

🎯 Why: During frequent UI rendering and DOM manipulation cycles, iterating over a `Set` using `.forEach()` introduces unnecessary overhead due to callback function allocation and dispatching. Replacing it with a native `for...of` loop avoids this overhead.

📊 Impact: Reduces garbage collection pressure and callback dispatch overhead in a UI rendering hot path, leading to smoother performance, especially on less powerful devices when processing invalid field highlights.

🔬 Measurement: Verify by interacting with form fields that trigger validation and error highlights, ensuring that error states are correctly cleared without noticeable lag. The tests in `node --test tests/*.test.js` also confirm that the logic remains correct.

---
*PR created automatically by Jules for task [3059729167955132767](https://jules.google.com/task/3059729167955132767) started by @Deltaporto*