### PR TITLE
🎨 Palette: Enable arrow key navigation for flowchart steps

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,7 @@
 ## 2025-05-17 - Programmatically Focused Native Elements
 **Learning:** Certain standard block elements used as wrappers (like `.simulador-details`, `.judicial-control`, `.flowchart-view`, `.sim-help-popover`) that receive programmatic focus via `tabindex="-1"` may lack consistent browser-default `:focus-visible` outlines just like `<dialog>` elements. Always explicitly style `:focus-visible` for these programmatic containers to ensure accessibility during keyboard navigation.
 **Action:** When creating programmatic focus targets for routing or focus-management (e.g. for skip links or modal-like popovers), always append them to the global `:focus-visible` outline styles list to ensure keyboard users have visual feedback that focus has successfully moved.
+
+## 2026-03-09 - Navigation Landmark Roving Tabindex
+**Learning:** Components functioning as semantic step navigations using native elements like `<nav>` inherently represent a structured group of links or buttons. Even when they lack an explicit `role="group"` due to their existing landmark role, they still require roving tabindex implementations if their children function as mutually exclusive toggle steps or tabs, as they will otherwise create a bloated tab order.
+**Action:** Always include step navigation containers (like `.flowchart-step-nav`) in the centralized roving tabindex logic (e.g., `groupSelector`) to ensure keyboard users can navigate their children efficiently using arrow keys instead of forcing sequential tab stops.

--- a/src/js/a11y.js
+++ b/src/js/a11y.js
@@ -29,7 +29,7 @@ export function initKeyboardNav() {
     return enabled;
   };
 
-  const groupSelector = '.note-buttons, .jc-q-buttons, .jc-segmented, .amb-tabs, .jc-segmented-wide, .app-mode-switch';
+  const groupSelector = '.note-buttons, .jc-q-buttons, .jc-segmented, .amb-tabs, .jc-segmented-wide, .app-mode-switch, .flowchart-step-nav';
 
   // Initialize static groups
   const groups = document.querySelectorAll(groupSelector);


### PR DESCRIPTION
💡 What: Added the `.flowchart-step-nav` container to the application's global `groupSelector` in `src/js/a11y.js`.
🎯 Why: The step navigation inside the flowchart acts like a group of mutually exclusive buttons. Previously, each button in the navigation was a separate tab stop, creating unnecessary clutter for keyboard users. Adding it to the roving tabindex allows keyboard users to focus the active step and use arrow keys to navigate.
📸 Before/After: Visuals unchanged, affects keyboard navigation only.
♿ Accessibility: Improves keyboard navigation efficiency by reducing tab stops.

---
*PR created automatically by Jules for task [16417661732859824430](https://jules.google.com/task/16417661732859824430) started by @Deltaporto*