### PR TITLE
⚡ Bolt: Eliminate Array.prototype.filter allocation in resolveCorpoJudFlow

### DIFF
--- a/src/js/judicial-flow.js
+++ b/src/js/judicial-flow.js
@@ -131,25 +131,28 @@ export function resolveCorpoJudFlow({
   }
 
   if (med.corpoChangeReason === 'dominio_max') {
-    const filledDomains = corpoDomainIds.filter(id => med.corpoAdminDomains[id] != null);
-    if (!filledDomains.length) {
-      return { ready: false, q: null, reason: 'No motivo "Domínio administrativo b1–b8 mais grave", informe ao menos um domínio b1 a b8.', mode: 'pending' };
-    }
-    // ⚡ Optimization: Native for-loop to avoid Array.prototype.reduce callback allocation overhead
+    // ⚡ Optimization: Single pass native loop avoids intermediate Array allocation from .filter()
     let q = 0;
     let domainsText = '';
-    for (let i = 0; i < filledDomains.length; i++) {
-      const id = filledDomains[i];
+    let hasFilled = false;
+    for (let i = 0; i < corpoDomainIds.length; i++) {
+      const id = corpoDomainIds[i];
       const val = med.corpoAdminDomains[id];
-      if (val > q) q = val;
+      if (val != null) {
+        hasFilled = true;
+        if (val > q) q = val;
 
-      // ⚡ Optimization: Native for-loop to avoid intermediate array allocation and .map callback overhead
-      const formattedDomain = `${id.toUpperCase()}=${qLabels[val]}`;
-      if (i === 0) {
-        domainsText = formattedDomain;
-      } else {
-        domainsText += ' · ' + formattedDomain;
+        // ⚡ Optimization: Native for-loop to avoid intermediate array allocation and .map callback overhead
+        const formattedDomain = `${id.toUpperCase()}=${qLabels[val]}`;
+        if (domainsText === '') {
+          domainsText = formattedDomain;
+        } else {
+          domainsText += ' · ' + formattedDomain;
+        }
       }
+    }
+    if (!hasFilled) {
+      return { ready: false, q: null, reason: 'No motivo "Domínio administrativo b1–b8 mais grave", informe ao menos um domínio b1 a b8.', mode: 'pending' };
     }
     return {
       ready: true,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -574,11 +574,12 @@ function openSimHelpPopover(helpKey, trigger) {
   titleEl.textContent = entry.title;
   summaryEl.textContent = entry.summary;
   const listFragment = document.createDocumentFragment();
-  entry.bullets.forEach(item => {
+  // ⚡ Optimization: Native for-loop to avoid Array.prototype.forEach callback allocation overhead in DOM rendering
+  for (let i = 0; i < entry.bullets.length; i++) {
     const li = document.createElement('li');
-    li.textContent = item;
+    li.textContent = entry.bullets[i];
     listFragment.appendChild(li);
-  });
+  }
   listEl.replaceChildren(listFragment);
   sourceEl.textContent = `Base legal: ${entry.source}`;
   excerptEl.textContent = entry.legalExcerpt || '';
@@ -761,14 +762,16 @@ function openPadraoDecisionDialog(context) {
     { label: 'Domínios manuais elegíveis: ', val: context.manuallyFilledEligible.length },
     { label: 'Não aplicáveis por corte etário: ', val: context.skippedByAgeCut }
   ];
-  summaryLines.forEach(line => {
+  // ⚡ Optimization: Native for-loop to avoid Array.prototype.forEach callback allocation overhead in DOM rendering
+  for (let i = 0; i < summaryLines.length; i++) {
+    const line = summaryLines[i];
     const div = document.createElement('div');
     const strong = document.createElement('strong');
     strong.textContent = line.label;
     div.appendChild(strong);
     div.appendChild(document.createTextNode(String(line.val)));
     summaryFragment.appendChild(div);
-  });
+  }
   summaryEl.replaceChildren(summaryFragment);
 
   preserveBtn.disabled = hasOnlyManual;


### PR DESCRIPTION
💡 What: Eliminated intermediate array allocation via `.filter()` in `resolveCorpoJudFlow` by using a single-pass native loop to filter values and calculate the max simultaneously.
🎯 Why: `resolveCorpoJudFlow` is called repeatedly during interactions in the Judicial Control flow. Using `.filter()` allocates an array in memory on each run, which introduces unnecessary garbage collection pressure and CPU cycles on a calculation path.
📊 Impact: Reduces memory allocation and GC pressure on every render interaction within the `dominio_max` judicial control mode. Removes one O(N) array allocation.
🔬 Measurement: Verified that tests pass (112 passed) and functionality is unchanged via the suite (`npm test`).

---
*PR created automatically by Jules for task [4227373372062453975](https://jules.google.com/task/4227373372062453975) started by @Deltaporto*