### PR TITLE
🎨 Palette: Add aria-haspopup="dialog" to help buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -75,3 +75,7 @@
 ## 2024-05-18 - Prevent hover state on disabled elements
 **Learning:** Native form elements (like `button`) support the `:disabled` pseudo-class natively, while standard elements like `a` or `label` do not. Applying `:not(:disabled)` to links will not work; instead, we must use `:not(.disabled):not([aria-disabled="true"])`.
 **Action:** Always verify if an element is a native form element before using `:disabled` in CSS pseudo-class selection to restrict interactive states.
+
+## 2026-03-09 - Dialog Triggers Missing aria-haspopup
+**Learning:** Help buttons and action buttons that open modals (like the `simHelpPopover` or confirmation dialogs) failed to inform screen reader users of the upcoming context change because they lacked `aria-haspopup="dialog"`.
+**Action:** Always verify that buttons whose primary function is to open a modal dialog implement `aria-haspopup="dialog"` to properly manage screen reader expectations.

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
             </svg>Aplicar padrão médio</button>
           <button type="button" class="sim-help-btn section-help-btn toolbar-help-btn" id="btnPadraoHelp"
             data-help-key="section.padrao_medio" aria-label="Entender o que é o padrão médio social"
-            aria-controls="simHelpPopover" aria-expanded="false">i</button>
+            aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button>
           <button class="btn btn-outline" id="btnLimpar" aria-haspopup="dialog"
             title="Limpa todos os domínios e redefine as opções da simulação."><svg class="ui-icon sm" aria-hidden="true">
               <use href="#i-trash"></use>
@@ -181,7 +181,7 @@
             </label>
             <button type="button" class="sim-help-btn section-help-btn toolbar-help-btn" id="btnImpedimentoHelp"
               data-help-key="concept.impedimento_lp" aria-label="Entender o conceito de impedimento de longo prazo"
-              aria-controls="simHelpPopover" aria-expanded="false">i</button>
+              aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button>
           </div>
         </div>
         <p class="toolbar-helper"><code>Aplicar padrão médio</code> aplica os domínios recomendados do perfil social
@@ -197,7 +197,7 @@
               <div>
                 <h2>Fatores Ambientais <button type="button" class="sim-help-btn section-help-btn" data-help-key="section.ambiente"
                     aria-label="Entender o conceito de Fatores Ambientais" aria-controls="simHelpPopover"
-                    aria-expanded="false">i</button></h2>
+                    aria-expanded="false" aria-haspopup="dialog">i</button></h2>
                 <div class="sub">Avaliação Social · 5 domínios (e1–e5)</div>
               </div>
             </div>
@@ -221,7 +221,7 @@
               <div>
                 <h2>Atividades e Participação <button type="button" class="sim-help-btn section-help-btn" data-help-key="section.atividades"
                     aria-label="Entender o conceito de Atividades e Participação" aria-controls="simHelpPopover"
-                    aria-expanded="false">i</button></h2>
+                    aria-expanded="false" aria-haspopup="dialog">i</button></h2>
                 <div class="sub">Misto · 9 domínios (d1–d9)</div>
               </div>
             </div>
@@ -250,7 +250,7 @@
               <div>
                 <h2>Funções do Corpo <button type="button" class="sim-help-btn section-help-btn" data-help-key="section.corpo"
                     aria-label="Entender o conceito de Funções do Corpo" aria-controls="simHelpPopover"
-                    aria-expanded="false">i</button></h2>
+                    aria-expanded="false" aria-haspopup="dialog">i</button></h2>
                 <div class="sub">Avaliação Médica · 8 domínios (b1–b8)</div>
               </div>
             </div>
@@ -515,7 +515,7 @@
                 <span id="jcImpedimentoLabel">Impedimento de longo prazo</span>
                 <button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn"
                   data-help-key="concept.impedimento_lp" aria-label="Entender o conceito de impedimento de longo prazo"
-                  aria-controls="simHelpPopover" aria-expanded="false">i</button>
+                  aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button>
               </div>
               <div class="jc-segmented" id="jcImpedimentoButtons" role="group" aria-labelledby="jcImpedimentoLabel">
                 <button class="jc-seg-btn" data-value="sim">Sim</button>

--- a/src/js/dom-builders.js
+++ b/src/js/dom-builders.js
@@ -50,6 +50,7 @@ export function buildDomainRows(container, domains, labels, names, domainHelpKey
       helpBtn.setAttribute('title', helpLabel);
       helpBtn.setAttribute('aria-controls', 'simHelpPopover');
       helpBtn.setAttribute('aria-expanded', 'false');
+      helpBtn.setAttribute('aria-haspopup', 'dialog');
       helpBtn.textContent = 'i';
       nameWrap.appendChild(helpBtn);
     }


### PR DESCRIPTION
💡 **What**: Added `aria-haspopup="dialog"` to all help buttons (`sim-help-btn`) that trigger the `simHelpPopover` dialog.
🎯 **Why**: To properly inform screen reader users that clicking these buttons will result in an interactive dialog opening, setting the correct interaction expectations before the action occurs.
📸 **Before/After**: No visual changes.
♿ **Accessibility**: Significant improvement for screen reader navigation predictability by utilizing `aria-haspopup="dialog"`.

---
*PR created automatically by Jules for task [17989569605294311977](https://jules.google.com/task/17989569605294311977) started by @Deltaporto*