### PR TITLE
🎨 Palette: Fix missing visual disabled styles for aria-disabled buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-03-09 - Navigation Landmark Roving Tabindex
 **Learning:** Components functioning as semantic step navigations using native elements like `<nav>` inherently represent a structured group of links or buttons. Even when they lack an explicit `role="group"` due to their existing landmark role, they still require roving tabindex implementations if their children function as mutually exclusive toggle steps or tabs, as they will otherwise create a bloated tab order.
 **Action:** Always include step navigation containers (like `.flowchart-step-nav`) in the centralized roving tabindex logic (e.g., `groupSelector`) to ensure keyboard users can navigate their children efficiently using arrow keys instead of forcing sequential tab stops.
+
+## 2024-06-12 - Aria-Disabled Styles on Buttons
+**Learning:** When using `aria-disabled="true"` on interactive components like `.btn` to maintain keyboard focusability while acting disabled, the visual disabled styling is often missed because it was only bound to `:disabled`. This leaves users confused about the button's state.
+**Action:** Explicitly pair visual disabled selectors (like `.btn:disabled, .btn[aria-disabled="true"]`) to keep visual and semantic states aligned.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -323,7 +323,8 @@ header p {
   gap: 6px
 }
 
-.btn:disabled {
+.btn:disabled,
+.btn[aria-disabled="true"] {
   cursor: not-allowed;
   opacity: 0.6;
   filter: grayscale(0.5);


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 What: Added the `.btn[aria-disabled="true"]` selector alongside `.btn:disabled` in the main CSS file to ensure consistent visual representation of disabled states for buttons managed via ARIA. Also added a journal entry documenting this learning.

🎯 Why: Interactive components that use `aria-disabled="true"` to maintain keyboard focusability while acting disabled often lack the visual disabled styling (like lowered opacity or cursor changes) because those styles are typically only bound to the native `:disabled` pseudo-class. This visual inconsistency can leave users confused about the button's actual interactive state.

📸 Before/After: Before this change, a button with `aria-disabled="true"` would look clickable even when functionally disabled. After, it looks visually disabled (opacity reduced, grayscale applied) mirroring the native disabled state.

♿ Accessibility: This directly improves the non-visual and visual accessibility mapping, ensuring that the semantic state communicated to screen readers (`aria-disabled="true"`) is consistently represented visually to all users.

---
*PR created automatically by Jules for task [1565365029906134212](https://jules.google.com/task/1565365029906134212) started by @Deltaporto*