### PR TITLE
🎨 Palette: Add pointer cursor to readonly textareas

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -79,3 +79,7 @@
 ## 2026-03-09 - Dialog Triggers Missing aria-haspopup
 **Learning:** Help buttons and action buttons that open modals (like the `simHelpPopover` or confirmation dialogs) failed to inform screen reader users of the upcoming context change because they lacked `aria-haspopup="dialog"`.
 **Action:** Always verify that buttons whose primary function is to open a modal dialog implement `aria-haspopup="dialog"` to properly manage screen reader expectations.
+
+## 2026-03-09 - Interactive Readonly Textareas
+**Learning:** Textareas marked as `readonly` but used as clickable elements to automatically copy text to the clipboard lack visual affordance for their interactivity, confusing users.
+**Action:** Always apply `cursor: pointer` to interactive `readonly` textareas (like `.standard-text textarea` or `.jc-textarea`) to indicate to users that the element can be clicked for an action.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3669,6 +3669,7 @@ header .badge {
   border: 1px solid var(--border);
   background: var(--bg-soft);
   font-size: .85rem;
+  cursor: pointer;
 }
 
 .jc-progress-wrap {


### PR DESCRIPTION
💡 What: Added `cursor: pointer` to interactive `readonly` textareas.
🎯 Why: Textareas that are `readonly` but clickable (to copy text) lacked visual affordance of their interactivity.
📸 Before/After: Before, hovering over the textareas showed the default text cursor. Now, it shows a pointer cursor.
♿ Accessibility: Improves cognitive accessibility by providing clear visual feedback that the element is interactive and can be clicked.

---
*PR created automatically by Jules for task [4677060959865785942](https://jules.google.com/task/4677060959865785942) started by @Deltaporto*