### PR TITLE
🎨 Palette: Add aria-haspopup to help buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,7 +546,7 @@
                     administrativo mais grave entre os informados.</p>
                   <div class="jc-complete-grid">
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB1Label">b1 · Funções Mentais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b1" aria-label="Entender b1 (Funções Mentais)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB1Label">b1 · Funções Mentais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b1" aria-label="Entender b1 (Funções Mentais)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB1Buttons" role="group" aria-labelledby="jcCorpoB1Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -556,7 +556,7 @@
                       </div>
                     </div>
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB2Label">b2 · Funções Sensoriais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b2" aria-label="Entender b2 (Funções Sensoriais)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB2Label">b2 · Funções Sensoriais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b2" aria-label="Entender b2 (Funções Sensoriais)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB2Buttons" role="group" aria-labelledby="jcCorpoB2Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -566,7 +566,7 @@
                       </div>
                     </div>
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB3Label">b3 · Voz e Fala</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b3" aria-label="Entender b3 (Voz e Fala)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB3Label">b3 · Voz e Fala</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b3" aria-label="Entender b3 (Voz e Fala)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB3Buttons" role="group" aria-labelledby="jcCorpoB3Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -576,7 +576,7 @@
                       </div>
                     </div>
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB4Label">b4 · Cardio/Hemato/Imuno/Respiratório</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b4" aria-label="Entender b4 (Cardio/Hemato/Imuno/Respiratório)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB4Label">b4 · Cardio/Hemato/Imuno/Respiratório</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b4" aria-label="Entender b4 (Cardio/Hemato/Imuno/Respiratório)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB4Buttons" role="group" aria-labelledby="jcCorpoB4Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -586,7 +586,7 @@
                       </div>
                     </div>
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB5Label">b5 · Digestivo/Metabólico-Endócrino</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b5" aria-label="Entender b5 (Digestivo/Metabólico-Endócrino)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB5Label">b5 · Digestivo/Metabólico-Endócrino</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b5" aria-label="Entender b5 (Digestivo/Metabólico-Endócrino)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB5Buttons" role="group" aria-labelledby="jcCorpoB5Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -596,7 +596,7 @@
                       </div>
                     </div>
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB6Label">b6 · Geniturinário e Reprodutivo</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b6" aria-label="Entender b6 (Geniturinário e Reprodutivo)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB6Label">b6 · Geniturinário e Reprodutivo</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b6" aria-label="Entender b6 (Geniturinário e Reprodutivo)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB6Buttons" role="group" aria-labelledby="jcCorpoB6Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -606,7 +606,7 @@
                       </div>
                     </div>
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB7Label">b7 · Neuromusculoesquelético e Movimento</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b7" aria-label="Entender b7 (Neuromusculoesquelético e Movimento)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB7Label">b7 · Neuromusculoesquelético e Movimento</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b7" aria-label="Entender b7 (Neuromusculoesquelético e Movimento)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB7Buttons" role="group" aria-labelledby="jcCorpoB7Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -616,7 +616,7 @@
                       </div>
                     </div>
                     <div class="jc-complete-item">
-                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB8Label">b8 · Pele e Estruturas Relacionadas</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b8" aria-label="Entender b8 (Pele e Estruturas Relacionadas)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                      <div class="jc-field-title jc-field-title-with-help"><span id="jcCorpoB8Label">b8 · Pele e Estruturas Relacionadas</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.b8" aria-label="Entender b8 (Pele e Estruturas Relacionadas)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                       <div class="jc-q-buttons" id="jcCorpoB8Buttons" role="group" aria-labelledby="jcCorpoB8Label">
                         <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                         <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -686,7 +686,7 @@
                   de Atividades e Participação.</p>
                 <div class="jc-complete-grid">
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD1Label">d1 · Aprendizagem</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d1" aria-label="Entender d1 (Aprendizagem)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD1Label">d1 · Aprendizagem</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d1" aria-label="Entender d1 (Aprendizagem)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD1Buttons" role="group" aria-labelledby="jcAtivD1Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -696,7 +696,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD2Label">d2 · Tarefas Gerais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d2" aria-label="Entender d2 (Tarefas Gerais)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD2Label">d2 · Tarefas Gerais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d2" aria-label="Entender d2 (Tarefas Gerais)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD2Buttons" role="group" aria-labelledby="jcAtivD2Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -706,7 +706,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD3Label">d3 · Comunicação</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d3" aria-label="Entender d3 (Comunicação)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD3Label">d3 · Comunicação</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d3" aria-label="Entender d3 (Comunicação)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD3Buttons" role="group" aria-labelledby="jcAtivD3Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -716,7 +716,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD4Label">d4 · Mobilidade</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d4" aria-label="Entender d4 (Mobilidade)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD4Label">d4 · Mobilidade</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d4" aria-label="Entender d4 (Mobilidade)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD4Buttons" role="group" aria-labelledby="jcAtivD4Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -726,7 +726,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD5Label">d5 · Cuidado Pessoal</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d5" aria-label="Entender d5 (Cuidado Pessoal)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD5Label">d5 · Cuidado Pessoal</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d5" aria-label="Entender d5 (Cuidado Pessoal)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD5Buttons" role="group" aria-labelledby="jcAtivD5Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -736,7 +736,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD6Label">d6 · Vida Doméstica</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d6" aria-label="Entender d6 (Vida Doméstica)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD6Label">d6 · Vida Doméstica</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d6" aria-label="Entender d6 (Vida Doméstica)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD6Buttons" role="group" aria-labelledby="jcAtivD6Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -746,7 +746,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD7Label">d7 · Relações Interpessoais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d7" aria-label="Entender d7 (Relações Interpessoais)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD7Label">d7 · Relações Interpessoais</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d7" aria-label="Entender d7 (Relações Interpessoais)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD7Buttons" role="group" aria-labelledby="jcAtivD7Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -756,7 +756,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD8Label">d8 · Áreas Principais da Vida</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d8" aria-label="Entender d8 (Áreas Principais da Vida)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD8Label">d8 · Áreas Principais da Vida</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d8" aria-label="Entender d8 (Áreas Principais da Vida)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD8Buttons" role="group" aria-labelledby="jcAtivD8Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>
@@ -766,7 +766,7 @@
                     </div>
                   </div>
                   <div class="jc-complete-item">
-                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD9Label">d9 · Vida Comunitária</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d9" aria-label="Entender d9 (Vida Comunitária)" aria-controls="simHelpPopover" aria-expanded="false">i</button></div>
+                    <div class="jc-field-title jc-field-title-with-help"><span id="jcAtivD9Label">d9 · Vida Comunitária</span><button type="button" class="sim-help-btn domain-help-btn jc-domain-help-btn" data-help-key="domain.d9" aria-label="Entender d9 (Vida Comunitária)" aria-controls="simHelpPopover" aria-expanded="false" aria-haspopup="dialog">i</button></div>
                     <div class="jc-q-buttons" id="jcAtivD9Buttons" role="group" aria-labelledby="jcAtivD9Label">
                       <button class="jc-q-btn" data-value="0" aria-label="Nenhuma">N</button>
                       <button class="jc-q-btn" data-value="1" aria-label="Leve">L</button>


### PR DESCRIPTION
💡 What: Added the `aria-haspopup="dialog"` attribute to all statically defined `sim-help-btn` elements in `index.html`.
🎯 Why: To properly manage screen reader expectations when interacting with buttons that trigger modal popovers.
📸 Before/After: Visuals remain exactly the same.
♿ Accessibility: Screen readers will now announce that these buttons open a dialog, enhancing context and predictability for users relying on assistive technologies.

---
*PR created automatically by Jules for task [11657140247158793647](https://jules.google.com/task/11657140247158793647) started by @Deltaporto*