### PR TITLE
⚡ Bolt: [performance improvement] Optimize Map initialization from DOM elements

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@ Instead, a significantly safer optimization is removing global queries like `doc
 ## 2026-05-18 - [Avoid NodeList and Array allocations in high-frequency event listeners]
 **Learning:** In global, high-frequency event listeners (like application-wide `keydown` for roving tabindex), continuously calling `querySelectorAll()` or manipulating resulting NodeLists with array-like operations (`Array.prototype.indexOf.call()`, `.forEach`) causes severe, measurable GC pressure and callback allocation overhead on every keystroke.
 **Action:** Replaced `querySelectorAll('button:not([disabled])')` with a faster native query (`getElementsByTagName('button')` returning an HTMLCollection) combined with a single manual native `for` loop to filter state. Eliminated all `.forEach` callbacks in favor of standard `for` loops in hot path event handlers to maximize keyboard navigation responsiveness.
+
+## 2025-05-19 - [DOM Query Optimization for Map Initialization]
+**Learning:** When initializing `Map` objects from DOM collections, utilizing array spread syntax and `.map()` (e.g., `new Map([...document.querySelectorAll('.my-class')].map(...))`) creates redundant intermediate arrays resulting in GC pressure and performance loss.
+**Action:** Replace `[...elements].map()` wrappers with native `for` loops utilizing `Map.prototype.set()` combined with live HTMLCollections like `getElementsByClassName` to eliminate intermediate allocation overhead and GC pressure.

--- a/src/js/ui-render.js
+++ b/src/js/ui-render.js
@@ -116,8 +116,11 @@ function ensureRefs() {
     decItem: getById('decItem'),
     textoSection: getById('textoSection')
   };
-  const ambTabs = [...document.querySelectorAll('.amb-tab')];
-  refs.ambTabMap = new Map(ambTabs.map(tab => [+tab.dataset.a, tab]));
+  const ambTabs = document.getElementsByClassName('amb-tab');
+  refs.ambTabMap = new Map();
+  for (let i = 0; i < ambTabs.length; i++) {
+    refs.ambTabMap.set(+ambTabs[i].dataset.a, ambTabs[i]);
+  }
   cachedRefs = refs;
   return refs;
 }


### PR DESCRIPTION
💡 What: Replaced `[...querySelectorAll].map()` with `getElementsByClassName` and a native `for` loop.
🎯 Why: To avoid intermediate array allocations and GC overhead in the `ensureRefs` rendering path.
📊 Impact: Eliminates two redundant array creations per execution, reducing GC pressure during initial render/DOM cache building.
🔬 Measurement: Observe reduction in memory allocations during application startup or first render when caching `.amb-tab` elements.

---
*PR created automatically by Jules for task [7891103154092440287](https://jules.google.com/task/7891103154092440287) started by @Deltaporto*