### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -11,7 +11,7 @@ const SECURITY_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Referrer-Policy': 'no-referrer',
-  'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none';",
+  'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none'; form-action 'none'; frame-ancestors 'none';",
   'Permissions-Policy': 'geolocation=(), camera=(), microphone=()',
   'Cross-Origin-Opener-Policy': 'same-origin',
   'Cross-Origin-Embedder-Policy': 'require-corp',


### PR DESCRIPTION
* **Severity:** MEDIUM
* **Vulnerability:** The `Content-Security-Policy` header explicitly emitted by the local development server in `scripts/serve.js` lacked the `form-action 'none';` directive. Even though this directive was present as a fallback in the HTML `<meta>` tags, HTTP headers take precedence and establish the baseline security posture.
* **Impact:** Without `form-action 'none'`, an attacker who manages to inject HTML into the application could theoretically construct a `<form>` and deceive users into submitting sensitive state to an external, malicious endpoint (form hijacking or cross-site request forgery).
* **Fix:** Appended `form-action 'none';` to the `Content-Security-Policy` header in `scripts/serve.js` to ensure uniform security rules across both HTML declarations and HTTP response headers.
* **Verification:** Run `node --test tests/*.test.js` to confirm server tests pass, and manually inspect the HTTP headers when running `node scripts/serve.js`.

---
*PR created automatically by Jules for task [15012573073347818248](https://jules.google.com/task/15012573073347818248) started by @Deltaporto*