### PR TITLE
🎨 Palette: [UX improvement] Replace text close icon with SVG in toasts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -83,3 +83,7 @@
 ## 2026-03-09 - Interactive Readonly Textareas
 **Learning:** Textareas marked as `readonly` but used as clickable elements to automatically copy text to the clipboard lack visual affordance for their interactivity, confusing users.
 **Action:** Always apply `cursor: pointer` to interactive `readonly` textareas (like `.standard-text textarea` or `.jc-textarea`) to indicate to users that the element can be clicked for an action.
+
+## 2026-03-09 - Inconsistent Dynamic Iconography (Text vs. SVG)
+**Learning:** Using plain text characters (like "×") for icons in dynamically generated DOM elements (like toast close buttons) causes subtle visual inconsistencies and alignment issues compared to components using the established SVG sprite system.
+**Action:** Always use the design system's consistent SVG sprites (`<svg><use href="#i-..."/></svg>`) for iconography in JavaScript-generated elements, rather than relying on raw text characters, to ensure uniform styling and scalability.

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -40,7 +40,14 @@ export function showToast(message, type = 'info', duration = 4000) {
   closeBtn.className = 'toast-close';
   closeBtn.setAttribute('aria-label', 'Fechar notificação');
   closeBtn.setAttribute('title', 'Fechar notificação');
-  closeBtn.textContent = '×';
+
+  const closeSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  closeSvg.setAttribute('class', 'ui-icon sm');
+  closeSvg.setAttribute('aria-hidden', 'true');
+  const closeUse = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+  closeUse.setAttribute('href', '#i-close');
+  closeSvg.appendChild(closeUse);
+  closeBtn.appendChild(closeSvg);
 
   toast.appendChild(iconDiv);
   toast.appendChild(messageDiv);


### PR DESCRIPTION
💡 **What**: Replaced the raw text "×" character in the dynamically generated toast close button with an SVG icon referencing `#i-close`.
🎯 **Why**: Using a plain text character introduces subtle visual inconsistencies and alignment issues across different browsers compared to the polished SVG icons used universally across the rest of the application.
📸 **Before/After**: The close button now perfectly matches the visual weight and stroke properties of all other interface icons.
♿ **Accessibility**: ARIA labels and `aria-hidden` properties were properly maintained so screen reader behavior remains unaffected.

---
*PR created automatically by Jules for task [13157076174202440487](https://jules.google.com/task/13157076174202440487) started by @Deltaporto*