### PR TITLE
🎨 Palette: Consistent Icon System for Dynamic Elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -45,3 +45,7 @@
 ## 2024-06-12 - Aria-Disabled Styles on Buttons
 **Learning:** When using `aria-disabled="true"` on interactive components like `.btn` to maintain keyboard focusability while acting disabled, the visual disabled styling is often missed because it was only bound to `:disabled`. This leaves users confused about the button's state.
 **Action:** Explicitly pair visual disabled selectors (like `.btn:disabled, .btn[aria-disabled="true"]`) to keep visual and semantic states aligned.
+
+## 2025-05-17 - Consistent Icon System for Dynamic Elements
+**Learning:** Using plain text characters (like "×") for close buttons in dynamically generated components (like toasts) causes alignment quirks and visual inconsistencies with the rest of the interface, which uses an SVG sprite system.
+**Action:** Consistently use the application's established SVG sprite system and `document.createElementNS` when dynamically creating DOM elements with icons to maintain visual harmony.

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -40,7 +40,14 @@ export function showToast(message, type = 'info', duration = 4000) {
   closeBtn.className = 'toast-close';
   closeBtn.setAttribute('aria-label', 'Fechar notificação');
   closeBtn.setAttribute('title', 'Fechar notificação');
-  closeBtn.textContent = '×';
+
+  const closeSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  closeSvg.setAttribute('class', 'ui-icon sm');
+  closeSvg.setAttribute('aria-hidden', 'true');
+  const closeUse = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+  closeUse.setAttribute('href', '#i-close');
+  closeSvg.appendChild(closeUse);
+  closeBtn.appendChild(closeSvg);
 
   toast.appendChild(iconDiv);
   toast.appendChild(messageDiv);


### PR DESCRIPTION
💡 What: Updated the dynamic toast close button to use the application's standard SVG sprite system instead of the plain text '×' character.
🎯 Why: Using plain text characters for close buttons caused alignment quirks and visual inconsistencies with the rest of the interface, which exclusively uses the SVG sprite system.
📸 Before/After: Before, toasts used a text character '×'. Now, they use the `#i-close` SVG sprite.
♿ Accessibility: The SVG is marked with `aria-hidden="true"` as the parent `<button>` already has descriptive `aria-label` attributes, maintaining the correct screen reader experience while improving visual polish.

---
*PR created automatically by Jules for task [2675604967418115025](https://jules.google.com/task/2675604967418115025) started by @Deltaporto*