### PR TITLE
🎨 Palette: Replace text close button with SVG icon in toast

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -83,3 +83,7 @@
 ## 2026-03-09 - Interactive Readonly Textareas
 **Learning:** Textareas marked as `readonly` but used as clickable elements to automatically copy text to the clipboard lack visual affordance for their interactivity, confusing users.
 **Action:** Always apply `cursor: pointer` to interactive `readonly` textareas (like `.standard-text textarea` or `.jc-textarea`) to indicate to users that the element can be clicked for an action.
+
+## 2026-03-10 - Consistent Icon Usage in Dynamic Elements
+**Learning:** Using plain text characters (like "×") for icons in dynamically created elements (like a toast close button) leads to visual inconsistencies and alignment quirks compared to the application's established SVG sprite system.
+**Action:** When dynamically creating DOM elements with icons via JavaScript, consistently use the application's established SVG sprite system and `document.createElementNS('http://www.w3.org/2000/svg', ...)` to maintain alignment and visual consistency.

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -40,7 +40,14 @@ export function showToast(message, type = 'info', duration = 4000) {
   closeBtn.className = 'toast-close';
   closeBtn.setAttribute('aria-label', 'Fechar notificação');
   closeBtn.setAttribute('title', 'Fechar notificação');
-  closeBtn.textContent = '×';
+
+  const closeSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  closeSvg.setAttribute('class', 'ui-icon sm');
+  closeSvg.setAttribute('aria-hidden', 'true');
+  const closeUse = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+  closeUse.setAttribute('href', '#i-close');
+  closeSvg.appendChild(closeUse);
+  closeBtn.appendChild(closeSvg);
 
   toast.appendChild(iconDiv);
   toast.appendChild(messageDiv);


### PR DESCRIPTION
💡 **What:** Replaced the plain-text "×" character in the dynamically generated toast close button with an actual SVG icon using the application's standard `#i-close` sprite.
🎯 **Why:** To maintain visual consistency and perfect alignment across the UI, leveraging the existing SVG sprite system rather than relying on standard text characters which can vary in alignment across fonts/browsers.
📸 **Before/After:** The toast close button now displays the exact same SVG icon used in other modals and popovers, rather than a generic text character.
♿ **Accessibility:** The newly injected SVG is correctly marked with `aria-hidden="true"`, ensuring the screen reader experience remains identical (reading the button's `aria-label`).

---
*PR created automatically by Jules for task [16080528934804847777](https://jules.google.com/task/16080528934804847777) started by @Deltaporto*